### PR TITLE
Feature/improve route

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,8 +141,9 @@ type Route struct {
 
 // RoutesCache represents a configuration of route cache.
 type RoutesCache struct {
-	Enable bool `yaml:"enable"`
-	Expire int  `yaml:"expire"`
+	Enable   bool `yaml:"enable"`
+	Expire   int  `yaml:"expire"`
+	Interval int  `yaml:"interval"`
 }
 
 func UnmarshalYAMLPath(path string) ([]Config, error) {

--- a/pkg/handler/server.go
+++ b/pkg/handler/server.go
@@ -201,6 +201,8 @@ func (h *hostHandler) Handle(ctx *fasthttp.RequestCtx) {
 	defer h.accessLog.Log(ctx)
 
 	result := h.routes.CachedRouteCtx(ctx)
+	defer result.Release()
+
 	if uri := result.RewriteURIWithQueryString(ctx); len(uri) > 0 {
 		ctx.Request.SetRequestURIBytes(uri)
 	}

--- a/pkg/logger/accesslog/accesslog.go
+++ b/pkg/logger/accesslog/accesslog.go
@@ -181,16 +181,17 @@ func (l *accessLog) Log(ctx *fasthttp.RequestCtx) {
 }
 
 func (l *accessLog) portFromAddr(addr string) []byte {
-	if portBytes := l.addrToPortCache.Get(addr); portBytes != nil {
+	key := util.CacheKeyString(addr)
+	if portBytes := l.addrToPortCache.Get(key); portBytes != nil {
 		return portBytes.([]byte)
 	}
 	_, port, err := net.SplitHostPort(addr)
 	if err != nil || port == "0" {
-		l.addrToPortCache.Set(addr, []byte{})
+		l.addrToPortCache.Set(key, []byte{})
 		return nil
 	}
 	portBytes := []byte(port)
-	l.addrToPortCache.Set(addr, portBytes)
+	l.addrToPortCache.Set(key, portBytes)
 	return portBytes
 }
 

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/fasthttpd/fasthttpd/pkg/config"
 	"github.com/fasthttpd/fasthttpd/pkg/util"
-	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
 )
 
@@ -110,6 +110,22 @@ func (r *Route) rewrite(path []byte) []byte {
 	return r.rewriteUriBytes
 }
 
+// acquireRoutesResult returns an empty RoutesResult object from the pool.
+//
+// The returned RoutesResult may be returned to the pool with Release when no
+// longer needed. This allows reducing GC load.
+func acquireRoutesResult() *RoutesResult {
+	return routesResultPool.Get().(*RoutesResult)
+}
+
+var routesResultPool = &sync.Pool{
+	New: func() interface{} {
+		r := &RoutesResult{}
+		r.reset()
+		return r
+	},
+}
+
 // RouteResult represents a result of routing.
 type RoutesResult struct {
 	StatusCode        int
@@ -121,18 +137,71 @@ type RoutesResult struct {
 	Filters           []string
 }
 
-func (r RoutesResult) RewriteURIWithQueryString(ctx *fasthttp.RequestCtx) []byte {
+func (r *RoutesResult) RewriteURIWithQueryString(ctx *fasthttp.RequestCtx) []byte {
 	if r.AppendQueryString && len(r.RewriteURI) > 0 {
 		return util.AppendQueryString(r.RewriteURI, ctx.URI().QueryString())
 	}
 	return r.RewriteURI
 }
 
-func (r RoutesResult) RedirectURIWithQueryString(ctx *fasthttp.RequestCtx) []byte {
+func (r *RoutesResult) RedirectURIWithQueryString(ctx *fasthttp.RequestCtx) []byte {
 	if r.AppendQueryString && len(r.RedirectURI) > 0 {
 		return util.AppendQueryString(r.RedirectURI, ctx.URI().QueryString())
 	}
 	return r.RedirectURI
+}
+
+func (r *RoutesResult) reset() {
+	r.StatusCode = 0
+	r.StatusMessage = r.StatusMessage[:0]
+	r.RewriteURI = r.RewriteURI[:0]
+	r.RedirectURI = r.RedirectURI[:0]
+	r.AppendQueryString = false
+	r.Handler = ""
+	r.Filters = r.Filters[:0]
+}
+
+func (r *RoutesResult) copyTo(dst *RoutesResult) *RoutesResult {
+	dst.reset()
+	dst.StatusCode = r.StatusCode
+	dst.StatusMessage = append(dst.StatusMessage[:0], r.StatusMessage...)
+	dst.RewriteURI = append(dst.RewriteURI[:0], r.RewriteURI...)
+	dst.RedirectURI = append(dst.RedirectURI, r.RedirectURI...)
+	dst.AppendQueryString = r.AppendQueryString
+	dst.Handler = r.Handler
+	dst.Filters = append(dst.Filters[:0], r.Filters...)
+	return dst
+}
+
+func (a *RoutesResult) equal(b *RoutesResult) bool {
+	if len(a.Filters) != len(b.Filters) {
+		return false
+	}
+	for i, f := range a.Filters {
+		if f != b.Filters[i] {
+			return false
+		}
+	}
+	return a.StatusCode == b.StatusCode &&
+		bytes.Equal(a.StatusMessage, b.StatusMessage) &&
+		bytes.Equal(a.RewriteURI, b.RewriteURI) &&
+		bytes.Equal(a.RedirectURI, b.RedirectURI) &&
+		a.AppendQueryString == b.AppendQueryString &&
+		a.Handler == b.Handler
+}
+
+// Release returns the object acquired via AcquireRoutesResult to the pool.
+//
+// Do not access the released RoutesResult object, otherwise data races may occur.
+func (r *RoutesResult) Release() {
+	r.reset()
+	routesResultPool.Put(r)
+}
+
+func onRoutesResultExpired(_ util.CacheKey, value interface{}) {
+	if r, ok := value.(*RoutesResult); ok {
+		r.Release()
+	}
 }
 
 // Routes represents a list of routes that can be used to match requested URLs.
@@ -163,14 +232,18 @@ func NewRoutes(cfg config.Config) (*Routes, error) {
 	}
 	rs := &Routes{routes: routes}
 	if cfg.RoutesCache.Enable {
-		rs.cache = util.NewExpireCache(int64(cfg.RoutesCache.Expire))
+		rs.cache = util.NewExpireCacheInterval(
+			int64(cfg.RoutesCache.Expire),
+			int64(cfg.RoutesCache.Interval),
+		)
+		rs.cache.OnExpired(onRoutesResultExpired)
 	}
 	return rs, nil
 }
 
 // Route find routes by the provided method and path and returns a new RoutesResult.
-func (rs Routes) Route(method, path []byte) *RoutesResult {
-	result := &RoutesResult{}
+func (rs *Routes) Route(method, path []byte) *RoutesResult {
+	result := acquireRoutesResult()
 	var uniqFilters map[string]bool
 	for _, r := range rs.routes {
 		if !r.Match(method, path) {
@@ -186,20 +259,16 @@ func (rs Routes) Route(method, path []byte) *RoutesResult {
 			}
 		}
 		result.StatusCode = r.statusCode
-		result.StatusMessage = r.statusMessageBytes
+		result.StatusMessage = append(result.StatusMessage[:0], r.statusMessageBytes...)
 		result.Handler = r.handler
 
 		if rewriteUri := r.rewrite(path); len(rewriteUri) > 0 {
 			result.AppendQueryString = r.rewriteAppendQueryString
-			if util.IsHttpOrHttps(rewriteUri) {
-				result.RedirectURI = rewriteUri
+			if util.IsHttpOrHttps(rewriteUri) || util.IsHttpStatusRedirect(result.StatusCode) {
+				result.RedirectURI = append(result.RedirectURI, rewriteUri...)
 				return result
 			}
-			if util.IsHttpStatusRedirect(result.StatusCode) {
-				result.RedirectURI = rewriteUri
-				return result
-			}
-			result.RewriteURI = rewriteUri
+			result.RewriteURI = append(result.RewriteURI[:0], rewriteUri...)
 			path, _ = util.SplitRequestURI(rewriteUri)
 		}
 		if result.StatusCode > 0 || result.Handler != "" {
@@ -211,27 +280,23 @@ func (rs Routes) Route(method, path []byte) *RoutesResult {
 }
 
 // CachedRoute provides Read-Through caching for rs.Route if the cache is enabled.
-func (rs Routes) CachedRoute(method, path []byte) *RoutesResult {
+func (rs *Routes) CachedRoute(method, path []byte) *RoutesResult {
 	if rs.cache == nil {
 		return rs.Route(method, path)
 	}
 
-	b := bytebufferpool.Get()
-	b.B = append(b.B, method...)
-	b.B = append(b.B, ' ')
-	b.B = append(b.B, path...)
-	key := b.String()
-	bytebufferpool.Put(b)
-
+	key := util.CacheKeyBytes(method, []byte{' '}, path)
 	if v := rs.cache.Get(key); v != nil {
-		return v.(*RoutesResult)
+		result := v.(*RoutesResult)
+		return result.copyTo(acquireRoutesResult())
 	}
+
 	result := rs.Route(method, path)
 	rs.cache.Set(key, result)
-	return result
+	return result.copyTo(acquireRoutesResult())
 }
 
 // CachedRouteCtx provides Read-Through caching for rs.Route if the cache is enabled.
-func (rs Routes) CachedRouteCtx(ctx *fasthttp.RequestCtx) *RoutesResult {
+func (rs *Routes) CachedRouteCtx(ctx *fasthttp.RequestCtx) *RoutesResult {
 	return rs.CachedRoute(ctx.Method(), ctx.Path())
 }

--- a/pkg/route/route_bench_test.go
+++ b/pkg/route/route_bench_test.go
@@ -1,0 +1,115 @@
+package route
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/fasthttpd/fasthttpd/pkg/config"
+	"github.com/jarxorg/tree"
+)
+
+var (
+	benchmarkRoutesConfig = config.Config{
+		Handlers: map[string]tree.Map{
+			"equal":  {},
+			"prefix": {},
+			"regexp": {},
+		},
+		Routes: []config.Route{
+			{
+				Path:    "/",
+				Match:   config.MatchEqual,
+				Handler: "equal",
+			}, {
+				Path:    "/img/",
+				Match:   config.MatchPrefix,
+				Handler: "prefix",
+			}, {
+				Path:    `.*\.(js|css|jpg|png|gif|ico)$`,
+				Match:   config.MatchRegexp,
+				Handler: "regexp",
+			},
+		},
+		RoutesCache: config.RoutesCache{
+			Enable: true,
+			Expire: 1000,
+		},
+	}
+	benchmarkRoutes, _ = NewRoutes(benchmarkRoutesConfig)
+)
+
+func benchmarkRoute(b *testing.B, method, path []byte, handler string) {
+	got := benchmarkRoutes.Route(method, path)
+	if got.Handler != handler {
+		b.Errorf("unexpected route result %#v", got)
+	}
+	got.Release()
+}
+
+func benchmarkCachedRoute(b *testing.B, method, path []byte, handler string) {
+	got := benchmarkRoutes.CachedRoute(method, path)
+	if got.Handler != handler {
+		b.Errorf("unexpected route result %#v", got)
+	}
+	got.Release()
+}
+
+func BenchmarkRoutes_Equal(b *testing.B) {
+	method := []byte(http.MethodGet)
+	path := []byte("/")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			benchmarkRoute(b, method, path, "equal")
+		}
+	})
+}
+
+func BenchmarkCachedRoutes_Equal(b *testing.B) {
+	method := []byte(http.MethodGet)
+	path := []byte("/")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			benchmarkCachedRoute(b, method, path, "equal")
+		}
+	})
+}
+
+func BenchmarkRoutes_Prefix(b *testing.B) {
+	method := []byte(http.MethodGet)
+	path := []byte("/img/test.png")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			benchmarkRoute(b, method, path, "prefix")
+		}
+	})
+}
+
+func BenchmarkCachedRoutes_Prefix(b *testing.B) {
+	method := []byte(http.MethodGet)
+	path := []byte("/img/test.png")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			benchmarkCachedRoute(b, method, path, "prefix")
+		}
+	})
+}
+
+func BenchmarkRoutes_Regexp(b *testing.B) {
+	method := []byte(http.MethodGet)
+	path := []byte("/favicon.ico")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			benchmarkRoute(b, method, path, "regexp")
+		}
+	})
+}
+
+func BenchmarkCachedRoutes_Regexp(b *testing.B) {
+	method := []byte(http.MethodGet)
+	path := []byte("/favicon.ico")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			benchmarkCachedRoute(b, method, path, "regexp")
+		}
+	})
+}

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,14 +1,53 @@
 package util
 
 import (
+	"hash"
+	"hash/fnv"
 	"sync"
 	"time"
 )
 
+var hash64Pool = sync.Pool{
+	New: func() interface{} {
+		return fnv.New64()
+	},
+}
+
+func acquireHash64() hash.Hash64 {
+	return hash64Pool.Get().(hash.Hash64)
+}
+
+func releaseHash64(h hash.Hash64) {
+	h.Reset()
+	hash64Pool.Put(h)
+}
+
+type CacheKey uint64
+
+func CacheKeyBytes(bs ...[]byte) CacheKey {
+	h := acquireHash64()
+	for _, b := range bs {
+		h.Write(b)
+	}
+	key := h.Sum64()
+	releaseHash64(h)
+	return CacheKey(key)
+}
+
+func CacheKeyString(s string) CacheKey {
+	h := acquireHash64()
+	h.Write([]byte(s))
+	key := h.Sum64()
+	releaseHash64(h)
+	return CacheKey(key)
+}
+
 // Cache is an interface that defines accessor of the cache.
 type Cache interface {
-	Get(key string) interface{}
-	Set(key string, value interface{})
+	Get(key CacheKey) interface{}
+	Set(key CacheKey, value interface{})
+	Len() int
+	OnExpired(cb func(key CacheKey, value interface{}))
 }
 
 const (
@@ -18,9 +57,12 @@ const (
 	defaultInterval = 60 * 1000
 )
 
-var expireCacheNow = func() int64 {
-	return time.Now().UnixMilli()
-}
+var (
+	expireCacheNow = func() int64 {
+		return time.Now().UnixMilli()
+	}
+	defaultOnExpired = func(key CacheKey, value interface{}) {}
+)
 
 type expireCacheValue struct {
 	value interface{}
@@ -28,11 +70,12 @@ type expireCacheValue struct {
 }
 
 type expireCache struct {
-	store    map[string]*expireCacheValue
-	expire   int64
-	interval int64
-	next     int64
-	mutex    sync.Mutex
+	store     map[CacheKey]*expireCacheValue
+	expire    int64
+	interval  int64
+	next      int64
+	mutex     sync.Mutex
+	onExpired func(key CacheKey, value interface{})
 }
 
 var _ Cache = (*expireCache)(nil)
@@ -40,7 +83,7 @@ var _ Cache = (*expireCache)(nil)
 // NewExpireCache returns a new cache with the specified expire (ms) and
 // default interval 1 min.
 func NewExpireCache(expire int64) Cache {
-	return NewExpireCacheInterval(expire, defaultInterval)
+	return NewExpireCacheInterval(expire, 0)
 }
 
 // NewExpireCacheInterval returns a new cache with the specified expire
@@ -49,16 +92,20 @@ func NewExpireCacheInterval(expire, interval int64) Cache {
 	if expire <= 0 {
 		expire = defaultExpire
 	}
+	if interval <= 0 {
+		interval = defaultInterval
+	}
 	return &expireCache{
-		store:    map[string]*expireCacheValue{},
-		expire:   expire,
-		interval: interval,
-		next:     expireCacheNow() + interval,
+		store:     make(map[CacheKey]*expireCacheValue),
+		expire:    expire,
+		interval:  interval,
+		next:      expireCacheNow() + interval,
+		onExpired: defaultOnExpired,
 	}
 }
 
 // Get returns the value mapped to the specified key and extends its expiration.
-func (c *expireCache) Get(key string) interface{} {
+func (c *expireCache) Get(key CacheKey) interface{} {
 	v := c.store[key]
 	if v == nil {
 		return nil
@@ -70,13 +117,25 @@ func (c *expireCache) Get(key string) interface{} {
 }
 
 // Set stores the value with key.
-func (c *expireCache) Set(key string, value interface{}) {
+func (c *expireCache) Set(key CacheKey, value interface{}) {
 	now := expireCacheNow()
 	c.store[key] = &expireCacheValue{
 		value: value,
 		peek:  now,
 	}
 	c.notify(now)
+}
+
+func (c *expireCache) Len() int {
+	return len(c.store)
+}
+
+func (c *expireCache) OnExpired(cb func(key CacheKey, value interface{})) {
+	if cb == nil {
+		c.onExpired = defaultOnExpired
+		return
+	}
+	c.onExpired = cb
 }
 
 func (c *expireCache) notify(now int64) {
@@ -103,6 +162,7 @@ func (c *expireCache) expires(now int64) {
 	for k, v := range c.store {
 		if now-v.peek > c.expire {
 			delete(c.store, k)
+			go c.onExpired(k, v.value)
 		}
 	}
 }

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -15,9 +15,9 @@ func Test_expireCache_Typical(t *testing.T) {
 	}
 
 	c := NewExpireCache(0).(*expireCache)
-	c.Set("key1", "value1")
-	c.Set("key2", "value2")
-	c.Set("key3", "value3")
+	c.Set(CacheKeyString("key1"), "value1")
+	c.Set(CacheKeyString("key2"), "value2")
+	c.Set(CacheKeyString("key3"), "value3")
 	if len(c.store) != 3 {
 		t.Fatalf("unexpected size %d\n", len(c.store))
 	}
@@ -27,11 +27,11 @@ func Test_expireCache_Typical(t *testing.T) {
 	c.next = 0
 
 	// NOTE: Get a value and extends its expiration.
-	if got := c.Get("key2"); got != "value2" {
+	if got := c.Get(CacheKeyString("key2")); got != "value2" {
 		t.Fatalf("unexpected value %v; want %v", got, "value2")
 	}
 
-	if got := c.Get("unknown"); got != nil {
+	if got := c.Get(CacheKeyString("unknown")); got != nil {
 		t.Fatalf("unexpected value %v", got)
 	}
 


### PR DESCRIPTION
- Reuse route.RoutesResult via sync.Pool
- Improve util.Cache


Before

```sh
% go test -bench=Route -benchmem -memprofile=mem.prof -cpuprofile=cpu.prof ./pkg/route/...
goos: darwin
goarch: arm64
pkg: github.com/fasthttpd/fasthttpd/pkg/route
BenchmarkRoutes_Equal-8          	23975185	        45.16 ns/op	     128 B/op	       1 allocs/op
BenchmarkCachedRoutes_Equal-8    	12914530	        99.09 ns/op	       5 B/op	       1 allocs/op
BenchmarkRoutes_Prefix-8         	26712596	        45.34 ns/op	     128 B/op	       1 allocs/op
BenchmarkCachedRoutes_Prefix-8   	12729596	        94.67 ns/op	      24 B/op	       1 allocs/op
BenchmarkRoutes_Regexp-8         	12622537	        96.67 ns/op	     132 B/op	       1 allocs/op
BenchmarkCachedRoutes_Regexp-8   	12501996	        95.00 ns/op	      16 B/op	       1 allocs/op
PASS
ok  	github.com/fasthttpd/fasthttpd/pkg/route	8.056s
```

After

```sh
% go test -bench=Route -benchmem -memprofile=mem.prof -cpuprofile=cpu.prof ./pkg/route/...
goos: darwin
goarch: arm64
pkg: github.com/fasthttpd/fasthttpd/pkg/route
BenchmarkRoutes_Equal-8          	327433689	        3.577 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachedRoutes_Equal-8    	29450773	        40.12 ns/op	       1 B/op	       1 allocs/op
BenchmarkRoutes_Prefix-8         	281970042	        4.253 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachedRoutes_Prefix-8   	28136815	        39.80 ns/op	       1 B/op	       1 allocs/op
BenchmarkRoutes_Regexp-8         	20191369	        55.48 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachedRoutes_Regexp-8   	28502349	        41.00 ns/op	       1 B/op	       1 allocs/op
PASS
ok  	github.com/fasthttpd/fasthttpd/pkg/route	8.344s
```