### PR TITLE
Fix relative config path

### DIFF
--- a/pkg/cmd/fasthttpd.go
+++ b/pkg/cmd/fasthttpd.go
@@ -88,10 +88,13 @@ func (d *FastHttpd) loadConfigs() ([]config.Config, error) {
 	if d.configFile == "" {
 		return []config.Config{newMinimalConfig()}, nil
 	}
-	if err := os.Chdir(filepath.Dir(d.configFile)); err != nil {
-		return nil, err
+	dir, file := filepath.Split(d.configFile)
+	if dir != "" {
+		if err := os.Chdir(dir); err != nil {
+			return nil, err
+		}
 	}
-	cfgs, err := config.UnmarshalYAMLPath(d.configFile)
+	cfgs, err := config.UnmarshalYAMLPath(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix an issue of specifing relative config file.

```sh
# Before
% fasthttpd -f ./examples/config.proxy.yaml
2022/08/16 19:04:09 open ./examples/config.proxy.yaml: no such file or directory
exit status 1

# After
% fasthttpd -f ./examples/config.proxy.yaml
2022/08/16 19:05:26 starting fasthttpd on ":8080"
```