### PR TITLE
Support 'root' in statusToPath

### DIFF
--- a/pkg/handler/errorpages.go
+++ b/pkg/handler/errorpages.go
@@ -15,7 +15,6 @@ var (
 
 // ErrorPages represents a handler that provides custom error pages.
 type ErrorPages struct {
-	root         string
 	statusToPath map[string]string
 	fs           fasthttp.RequestHandler
 	errorPaths   [][]byte
@@ -26,7 +25,11 @@ var _ fasthttp.RequestHandler = (*ErrorPages)(nil).Handle
 // NewErrorPages creates a new ErrorPages.
 // The statusToPath maps from a http status text to a path of error page.
 // A http status text can be contain 'x' as wildcard. (eg. '404', '40x')
+// If 'root' is specified in statusToPath, it overrides the default root.
 func NewErrorPages(root string, statusToPath map[string]string) *ErrorPages {
+	if overrideRoot, ok := statusToPath["root"]; ok {
+		root = overrideRoot
+	}
 	if len(root) == 0 || len(statusToPath) == 0 {
 		return &ErrorPages{}
 	}
@@ -35,7 +38,6 @@ func NewErrorPages(root string, statusToPath map[string]string) *ErrorPages {
 		Compress: true,
 	}
 	return &ErrorPages{
-		root:         root,
 		statusToPath: statusToPath,
 		fs:           fs.NewRequestHandler(),
 		errorPaths:   make([][]byte, errorPagesStatusUntil-errorPagesStatusOffset),

--- a/pkg/handler/errorpages_test.go
+++ b/pkg/handler/errorpages_test.go
@@ -20,10 +20,11 @@ func TestErrorPages(t *testing.T) {
 	}
 	ctx := &fasthttp.RequestCtx{}
 
-	errorPages := NewErrorPages("testdata/public", map[string]string{
-		"400": "/err/400.html",
-		"404": "/err/404.html",
-		"5xx": "/err/5xx.html",
+	errorPages := NewErrorPages("", map[string]string{
+		"root": "testdata/public",
+		"400":  "/err/400.html",
+		"404":  "/err/404.html",
+		"5xx":  "/err/5xx.html",
 	})
 
 	tests := []struct {


### PR DESCRIPTION
If 'root' is specified in statusToPath, it overrides the default root.