### PR TITLE
Enable errorPages with emptyRoot

### DIFF
--- a/pkg/handler/errorpages_test.go
+++ b/pkg/handler/errorpages_test.go
@@ -115,7 +115,7 @@ func TestErrorPages(t *testing.T) {
 	}
 
 	wantErrorPaths := make([][]byte, 200)
-	wantErrorPaths[400-errorPagesStatusOffset] = []byte{}
+	wantErrorPaths[400-errorPagesStatusOffset] = []byte{'-'}
 	wantErrorPaths[403-errorPagesStatusOffset] = []byte{}
 	wantErrorPaths[404-errorPagesStatusOffset] = []byte("/err/404.html")
 	wantErrorPaths[500-errorPagesStatusOffset] = []byte("/err/5xx.html")


### PR DESCRIPTION
If '-' specified to errorPages route to default error pages.