### PR TITLE
ci: Introduce golangci-lint and fix existing warnings

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,3 +24,8 @@ jobs:
       -
         name: Run go test
         run: go test -race ./...
+      -
+        name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+linters:
+  default: standard
+  exclusions:
+    rules:
+      # Test files commonly discard the return value of defer *.Close()
+      # and os.RemoveAll on temp dirs; treat errcheck as noise there.
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/pkg/cmd/fasthttpd.go
+++ b/pkg/cmd/fasthttpd.go
@@ -205,7 +205,7 @@ func (d *FastHttpd) run() error {
 		if err != nil {
 			return err
 		}
-		defer h.Close()
+		defer func() { _ = h.Close() }()
 
 		server, err := d.newServer(h)
 		if err != nil {

--- a/pkg/handler/content.go
+++ b/pkg/handler/content.go
@@ -75,11 +75,12 @@ func (h *Content) Handle(ctx *fasthttp.RequestCtx) {
 			args := ctx.Request.URI().QueryArgs()
 			condArgs := fasthttp.AcquireArgs()
 			condArgs.Parse(condCfg.Get("queryStringContains").Value().String())
-			condArgs.VisitAll(func(key, value []byte) {
-				if matches && !bytes.Equal(args.PeekBytes(key), value) {
+			for key, value := range condArgs.All() {
+				if !bytes.Equal(args.PeekBytes(key), value) {
 					matches = false
+					break
 				}
-			})
+			}
 			fasthttp.ReleaseArgs(condArgs)
 			if matches {
 				h.output(ctx, condCfg.Map())

--- a/pkg/handler/server_test.go
+++ b/pkg/handler/server_test.go
@@ -129,10 +129,11 @@ func assertResponse(resp *fasthttp.Response, status int, body string, headers []
 	if !bytes.Contains(gotBody, []byte(body)) {
 		return fmt.Errorf("unexpected body %q; want contains %s", gotBody, body)
 	}
-	resp.Header.VisitAll(func(key, value []byte) {
+outer:
+	for key, value := range resp.Header.All() {
 		strKey := string(key)
 		if strKey == "Date" {
-			return
+			continue
 		}
 		for j, kv := range headers {
 			k, v := kv[0], kv[1]
@@ -141,11 +142,11 @@ func assertResponse(resp *fasthttp.Response, status int, body string, headers []
 					err = fmt.Errorf("unexpected header %s: %s; want %s", k, value, v)
 				}
 				headers = append(headers[:j], headers[j+1:]...)
-				return
+				continue outer
 			}
 		}
 		err = fmt.Errorf("unnecessary header %s: %s", key, value)
-	})
+	}
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

- Add a minimal `.golangci.yml` that enables the golangci-lint v2 standard preset (`errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`) and relaxes `errcheck` inside `_test.go`, where deferred `*.Close()` and `os.RemoveAll` on temp dirs are common and intentional.
- Wire the linter into `tests.yaml` via `golangci-lint-action@v9` pinned to `v2.11.4`.
- Fix the three production warnings surfaced by the new configuration:
  - `pkg/cmd/fasthttpd.go`: wrap the deferred `h.Close()` so errcheck sees the return value being explicitly discarded.
  - `pkg/handler/content.go`: replace the deprecated `Args.VisitAll` with a range loop over `Args.All()`. This also lets the loop break as soon as a mismatch is found, instead of walking every key.
  - `pkg/handler/server_test.go`: replace `ResponseHeader.VisitAll` with a range loop over `ResponseHeader.All()`, using a labeled continue in place of the callback-style return. Deprecation warnings are not relaxed in `_test.go`, so this gets fixed alongside the production site.

PR3 of the `feature/ci-lint-refresh` series. Targets the integration branch, not `main`.

## Test plan

- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] `actionlint` passes