### PR TITLE
build: Inject version via ldflags and strip debug info

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,8 @@ builds:
     binary: fasthttpd
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/fasthttpd/fasthttpd/pkg/cmd.version={{.Version}}
     goos:
       - linux
       - windows

--- a/pkg/cmd/fasthttpd.go
+++ b/pkg/cmd/fasthttpd.go
@@ -28,8 +28,9 @@ import (
 // indicates the default configuration file path.
 const EnvFasthttpdConfig = "FASTHTTPD_CONFIG"
 
-// version will update by github actions.
-const version = "0.5.4"
+// version is injected at build time via -ldflags "-X ...version=...".
+// Defaults to "dev" for `go install` / `go run` style builds.
+var version = "dev"
 
 const (
 	cmd          = "fasthttpd"


### PR DESCRIPTION
## Summary

- Move the `version` constant in `pkg/cmd/fasthttpd.go` to a `var` with a `"dev"` default and let GoReleaser supply the real value at build time via `-ldflags -X`. The hand-edited const previously had to be bumped manually before every release, which its own comment already promised was automated but was not.
- Add `-s -w` to the same ldflags. `darwin/arm64` snapshot builds drop from 13.93 MiB to 9.68 MiB (-30.5%) with no observable runtime cost: panic stack traces still resolve function names and line numbers, and pprof-based profiling continues to work. The only thing given up is DWARF debug info for delve/gdb on the release binary, which is not how a fasthttpd release is ever debugged in practice.

## Size comparison (darwin/arm64, CGO_ENABLED=0)

| build | size | delta |
|---|---:|---:|
| no ldflags | 14,601,954 B (13.93 MiB) | baseline |
| `-X ...version=0.5.4` only | 14,602,034 B (13.93 MiB) | +80 B |
| `-s -w -X ...version=0.5.4` | 10,147,282 B (9.68 MiB) | **−30.5%** |

PR5 of the `feature/ci-lint-refresh` series. Targets the integration branch, not `main`. This is the last PR in the series; once merged, `feature/ci-lint-refresh` is ready to go to `main`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `goreleaser build --snapshot --clean --single-target` — produces a 10,147,282 B binary that prints `0.5.5-next` for `fasthttpd -v`, confirming both the ldflags injection path and `-s -w` stripping work end-to-end