### PR TITLE
perf(util): Zero-alloc CacheKeyBuilder with separator-safe maphash

### DIFF
--- a/pkg/logger/accesslog/accesslog.go
+++ b/pkg/logger/accesslog/accesslog.go
@@ -203,7 +203,7 @@ func (l *accessLog) Log(ctx *fasthttp.RequestCtx) {
 }
 
 func (l *accessLog) portFromAddr(addr string) []byte {
-	key := util.CacheKeyString(addr)
+	key := util.CacheKeyOfString(addr)
 	if portBytes := l.addrToPortCache.Get(key); portBytes != nil {
 		return portBytes.([]byte)
 	}

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -204,8 +204,12 @@ func (rs *Routes) CachedRoute(method, path []byte, off int) *Result {
 		return rs.Route(method, path, off)
 	}
 
-	// Stack-allocated scratch for the offset. The key builder writes
-	// length-prefixed fields so the three components (off, method, path)
+	// Encode off into a 4-byte little-endian scratch on the stack.
+	// off is the route-table start index and must be part of the key
+	// because the same (method, path) can resolve to a different route
+	// depending on where the search starts. A fixed-size [4]byte avoids
+	// the heap allocation that strconv.Itoa would incur.
+	// The key builder length-prefixes each field so (off, method, path)
 	// never collide with a different split of the same concatenated
 	// bytes.
 	var offBuf [4]byte

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/fasthttpd/fasthttpd/pkg/config"
 	"github.com/fasthttpd/fasthttpd/pkg/util"
@@ -123,7 +122,6 @@ func onResultReleased(_ util.CacheKey, value interface{}) {
 type Routes struct {
 	routes []*Route
 	cache  util.Cache
-	intBuf sync.Pool
 }
 
 // NewRoutes creates a new Routes the provided cfg.Routes.
@@ -200,31 +198,25 @@ func (rs *Routes) Route(method, path []byte, off int) *Result {
 	return result
 }
 
-func (rs *Routes) acquireIntBuf() []byte {
-	x := rs.intBuf.Get()
-	if x != nil {
-		return *(x.(*[]byte))
-	}
-	return make([]byte, 4)
-}
-
-func (rs *Routes) releaseIntBuf(b []byte) {
-	for i := range b {
-		b[i] = 0
-	}
-	rs.intBuf.Put(&b)
-}
-
 // CachedRoute provides Read-Through caching for rs.Route if the cache is enabled.
 func (rs *Routes) CachedRoute(method, path []byte, off int) *Result {
 	if rs.cache == nil {
 		return rs.Route(method, path, off)
 	}
 
-	b := rs.acquireIntBuf()
-	binary.LittleEndian.PutUint32(b, uint32(off))
-	key := util.CacheKeyBytes(b, method, []byte{0}, path)
-	rs.releaseIntBuf(b)
+	// Stack-allocated scratch for the offset. The key builder writes
+	// length-prefixed fields so the three components (off, method, path)
+	// never collide with a different split of the same concatenated
+	// bytes.
+	var offBuf [4]byte
+	binary.LittleEndian.PutUint32(offBuf[:], uint32(off))
+
+	kb := util.AcquireCacheKeyBuilder()
+	kb.Write(offBuf[:])
+	kb.Write(method)
+	kb.Write(path)
+	key := kb.Sum()
+	util.ReleaseCacheKeyBuilder(kb)
 
 	if v := rs.cache.Get(key); v != nil {
 		result := v.(*Result)

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -27,6 +27,10 @@ var cacheKeySeed = maphash.MakeSeed()
 // concurrent use.
 type CacheKeyBuilder struct {
 	h      maphash.Hash
+	// lenBuf is a 4-byte scratch reused by Write/WriteString to emit
+	// the length prefix before each field. Keeping it on the struct
+	// (which itself lives in a sync.Pool) means the prefix write stays
+	// allocation-free across calls.
 	lenBuf [4]byte
 }
 

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,47 +1,103 @@
 package util
 
 import (
-	"hash"
-	"hash/crc64"
+	"encoding/binary"
+	"hash/maphash"
 	"sync"
 	"time"
 )
 
-var hash64Pool = sync.Pool{
-	New: func() interface{} {
-		return crc64.New(crc64.MakeTable(crc64.ISO))
+// CacheKey is a 64-bit hashed cache key.
+type CacheKey uint64
+
+// cacheKeySeed is a single process-wide seed shared by every builder and
+// shortcut helper so that equal inputs always produce equal CacheKeys.
+// It is randomized at package init, which gives fasthttpd hash-flooding
+// resistance against adversarial HTTP paths while still letting Set and
+// Get within the same process agree on the same key.
+var cacheKeySeed = maphash.MakeSeed()
+
+// CacheKeyBuilder accumulates length-prefixed fields and produces a
+// CacheKey that is safe against composition ambiguity — that is, the
+// fields ("ab", "c") and ("a", "bc") produce different keys.
+//
+// Acquire from the pool with AcquireCacheKeyBuilder, call Write /
+// WriteString as many times as needed, call Sum to finalize, then
+// release it with ReleaseCacheKeyBuilder. Builders are not safe for
+// concurrent use.
+type CacheKeyBuilder struct {
+	h      maphash.Hash
+	lenBuf [4]byte
+}
+
+var cacheKeyBuilderPool = sync.Pool{
+	New: func() any {
+		b := &CacheKeyBuilder{}
+		b.h.SetSeed(cacheKeySeed)
+		return b
 	},
 }
 
-func acquireHash64() hash.Hash64 {
-	return hash64Pool.Get().(hash.Hash64)
+// AcquireCacheKeyBuilder fetches a reusable builder from the pool. The
+// returned builder has an empty hash state but keeps the shared seed,
+// so successive Acquire/Release cycles produce consistent keys.
+func AcquireCacheKeyBuilder() *CacheKeyBuilder {
+	b := cacheKeyBuilderPool.Get().(*CacheKeyBuilder)
+	b.h.Reset()
+	return b
 }
 
-func releaseHash64(h hash.Hash64) {
-	h.Reset()
-	hash64Pool.Put(h)
+// ReleaseCacheKeyBuilder returns a builder to the pool. After calling
+// this, the caller must not touch b again.
+func ReleaseCacheKeyBuilder(b *CacheKeyBuilder) {
+	cacheKeyBuilderPool.Put(b)
 }
 
-type CacheKey uint64
-
-func CacheKeyBytes(bs ...[]byte) CacheKey {
-	h := acquireHash64()
-	for _, b := range bs {
-		h.Write(b)
-	}
-	key := h.Sum64()
-	releaseHash64(h)
-	return CacheKey(key)
+// Write appends a length-prefixed byte-slice field to the key.
+func (b *CacheKeyBuilder) Write(p []byte) {
+	binary.LittleEndian.PutUint32(b.lenBuf[:], uint32(len(p)))
+	b.h.Write(b.lenBuf[:])
+	b.h.Write(p)
 }
 
-func CacheKeyString(ss ...string) CacheKey {
-	h := acquireHash64()
-	for _, s := range ss {
-		h.Write([]byte(s))
-	}
-	key := h.Sum64()
-	releaseHash64(h)
-	return CacheKey(key)
+// WriteString appends a length-prefixed string field to the key.
+// Uses maphash's native WriteString so no copy of s is needed.
+func (b *CacheKeyBuilder) WriteString(s string) {
+	binary.LittleEndian.PutUint32(b.lenBuf[:], uint32(len(s)))
+	b.h.Write(b.lenBuf[:])
+	b.h.WriteString(s)
+}
+
+// Sum finalizes and returns the cache key. The builder can continue to
+// be reused for further Write calls after Sum if desired, but typically
+// the caller releases it immediately after Sum.
+func (b *CacheKeyBuilder) Sum() CacheKey {
+	return CacheKey(b.h.Sum64())
+}
+
+// CacheKeyOf is a shortcut for a single-field byte-slice key. It is
+// equivalent to acquiring a builder, calling Write(p), Sum, and
+// releasing, but avoids the pool round-trip for the common single
+// field case.
+func CacheKeyOf(p []byte) CacheKey {
+	var h maphash.Hash
+	h.SetSeed(cacheKeySeed)
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], uint32(len(p)))
+	h.Write(lenBuf[:])
+	h.Write(p)
+	return CacheKey(h.Sum64())
+}
+
+// CacheKeyOfString is the string counterpart of CacheKeyOf.
+func CacheKeyOfString(s string) CacheKey {
+	var h maphash.Hash
+	h.SetSeed(cacheKeySeed)
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], uint32(len(s)))
+	h.Write(lenBuf[:])
+	h.WriteString(s)
+	return CacheKey(h.Sum64())
 }
 
 // Cache is an interface that defines accessor of the cache.

--- a/pkg/util/cache_bench_test.go
+++ b/pkg/util/cache_bench_test.go
@@ -1,43 +1,43 @@
 package util
 
 import (
+	"encoding/binary"
 	"testing"
-
-	"github.com/valyala/bytebufferpool"
 )
 
-func benchmarkBytesToKey(b *testing.B, fn func(bs ...[]byte) interface{}) {
+// BenchmarkCacheKeyBuilder_RouterKey mirrors the three-field shape that
+// pkg/route/route.go.CachedRoute builds for every cached lookup: a
+// little-endian uint32 offset, the HTTP method, and the URL path. The
+// expectation is 0 B/op, 0 allocs/op — any regression here means a
+// field has started escaping again.
+func BenchmarkCacheKeyBuilder_RouterKey(b *testing.B) {
+	var offBuf [4]byte
+	binary.LittleEndian.PutUint32(offBuf[:], 42)
+	method := []byte("GET")
+	path := []byte("/api/users/123")
+
+	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
-		bs := [][]byte{
-			[]byte("GET"),
-			[]byte(" "),
-			{0},
-		}
-		i := 0
 		for pb.Next() {
-			i++
-			bs[2][0] = byte(i % 256)
-			fn(bs...)
+			kb := AcquireCacheKeyBuilder()
+			kb.Write(offBuf[:])
+			kb.Write(method)
+			kb.Write(path)
+			_ = kb.Sum()
+			ReleaseCacheKeyBuilder(kb)
 		}
 	})
 }
 
-func BenchmarkBytesToKey_CacheKeyBytes(b *testing.B) {
-	fn := func(bs ...[]byte) interface{} {
-		return CacheKeyBytes(bs...)
-	}
-	benchmarkBytesToKey(b, fn)
-}
+// BenchmarkCacheKeyOfString covers the single-field shortcut used by
+// pkg/logger/accesslog. Expected: 0 B/op, 0 allocs/op.
+func BenchmarkCacheKeyOfString(b *testing.B) {
+	const addr = "192.168.1.1:54321"
 
-func BenchmarkBytesToKey_BytebufferpoolString(b *testing.B) {
-	fn := func(bs ...[]byte) interface{} {
-		p := bytebufferpool.Get()
-		for _, bb := range bs {
-			p.B = append(p.B, bb...)
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = CacheKeyOfString(addr)
 		}
-		key := string(p.B)
-		bytebufferpool.Put(p)
-		return key
-	}
-	benchmarkBytesToKey(b, fn)
+	})
 }

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -6,10 +6,89 @@ import (
 )
 
 func TestCacheKey(t *testing.T) {
-	b := CacheKeyBytes([]byte("GET"), []byte{' '}, []byte("/path"))
-	s := CacheKeyString("GET", " ", "/path")
-	if b != s {
-		t.Errorf("different results CacheKeyBytes %d, CacheKeyString %d", b, s)
+	// Write and WriteString must produce the same key for the same
+	// field contents, so a caller can freely pick whichever type is
+	// more convenient without breaking cache lookups.
+	kbBytes := AcquireCacheKeyBuilder()
+	kbBytes.Write([]byte("GET"))
+	kbBytes.Write([]byte(" "))
+	kbBytes.Write([]byte("/path"))
+	byKey := kbBytes.Sum()
+	ReleaseCacheKeyBuilder(kbBytes)
+
+	kbStr := AcquireCacheKeyBuilder()
+	kbStr.WriteString("GET")
+	kbStr.WriteString(" ")
+	kbStr.WriteString("/path")
+	strKey := kbStr.Sum()
+	ReleaseCacheKeyBuilder(kbStr)
+
+	if byKey != strKey {
+		t.Errorf("Write and WriteString disagree: %d vs %d", byKey, strKey)
+	}
+}
+
+// TestCacheKey_FieldSeparator guards against the classic hash-composition
+// bug where concatenating fields without a delimiter lets ("ab", "c") and
+// ("a", "bc") collide. The length-prefix scheme inside CacheKeyBuilder
+// makes these inputs produce distinct keys.
+func TestCacheKey_FieldSeparator(t *testing.T) {
+	build := func(fields ...string) CacheKey {
+		kb := AcquireCacheKeyBuilder()
+		for _, f := range fields {
+			kb.WriteString(f)
+		}
+		key := kb.Sum()
+		ReleaseCacheKeyBuilder(kb)
+		return key
+	}
+
+	testCases := []struct {
+		caseName string
+		a, b     []string
+	}{
+		{
+			caseName: "two-field split",
+			a:        []string{"ab", "c"},
+			b:        []string{"a", "bc"},
+		},
+		{
+			caseName: "three-field split",
+			a:        []string{"GET", "/api", "/users"},
+			b:        []string{"GE", "T/api/", "users"},
+		},
+		{
+			caseName: "empty-field sensitivity",
+			a:        []string{"", "foo"},
+			b:        []string{"foo"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := build(tc.a...); got == build(tc.b...) {
+				t.Errorf("field split %v and %v collide on key %d", tc.a, tc.b, got)
+			}
+		})
+	}
+}
+
+// TestCacheKey_ShortcutMatchesBuilder verifies that the single-field
+// shortcut helpers produce the same value as calling the builder with
+// one field — otherwise callers that mix them in the same cache would
+// silently see misses.
+func TestCacheKey_ShortcutMatchesBuilder(t *testing.T) {
+	const s = "192.168.1.1:54321"
+
+	kb := AcquireCacheKeyBuilder()
+	kb.WriteString(s)
+	builderKey := kb.Sum()
+	ReleaseCacheKeyBuilder(kb)
+
+	if got := CacheKeyOfString(s); got != builderKey {
+		t.Errorf("CacheKeyOfString = %d, builder = %d", got, builderKey)
+	}
+	if got := CacheKeyOf([]byte(s)); got != builderKey {
+		t.Errorf("CacheKeyOf = %d, builder = %d", got, builderKey)
 	}
 }
 
@@ -23,9 +102,9 @@ func Test_expireCache(t *testing.T) {
 	}
 
 	c := NewExpireCache(0).(*expireCache)
-	c.Set(CacheKeyString("key1"), "value1")
-	c.Set(CacheKeyString("key2"), "value2")
-	c.Set(CacheKeyString("key3"), "value3")
+	c.Set(CacheKeyOfString("key1"), "value1")
+	c.Set(CacheKeyOfString("key2"), "value2")
+	c.Set(CacheKeyOfString("key3"), "value3")
 	if c.Len() != 3 {
 		t.Fatalf("unexpected size %d\n", c.Len())
 	}
@@ -37,11 +116,11 @@ func Test_expireCache(t *testing.T) {
 	c.mutex.Unlock()
 
 	// NOTE: Get a value and extends its expiration.
-	if got := c.Get(CacheKeyString("key2")); got != "value2" {
+	if got := c.Get(CacheKeyOfString("key2")); got != "value2" {
 		t.Fatalf("unexpected value %v; want %v", got, "value2")
 	}
 
-	if got := c.Get(CacheKeyString("unknown")); got != nil {
+	if got := c.Get(CacheKeyOfString("unknown")); got != nil {
 		t.Fatalf("unexpected value %v", got)
 	}
 
@@ -73,7 +152,7 @@ func Test_expireCache_OnRelease(t *testing.T) {
 	}
 
 	done := make(chan bool)
-	key := CacheKeyString("key")
+	key := CacheKeyOfString("key")
 	value := "value"
 
 	c := NewExpireCacheInterval(1, 1).(*expireCache)


### PR DESCRIPTION
## Summary

Rewrites the cache-key machinery around a pooled `CacheKeyBuilder` backed by `hash/maphash`, and migrates the two callers off the old variadic `CacheKeyBytes` / `CacheKeyString` API. The router cache lookup path becomes **fully allocation-free** and the composition-ambiguity bug in the old API is gone.

## Two problems in the old API

**Separator ambiguity.** `CacheKeyBytes` / `CacheKeyString` were variadic and concatenated every field into a single hash stream with no delimiter, so `("ab","c")` and `("a","bc")` collided. `pkg/route/route.go` was patching over this by manually inserting a `\0` byte between `method` and `path`, but the workaround was fragile — any future caller that added a field would silently reopen the hole.

**Allocations on the router hot path.** Despite a `sync.Pool` for the CRC64 hasher, `BenchmarkCachedRoutes_*` was showing 2 allocs / 25 B per call. Escape analysis pinpointed both:

- `rs.intBuf.Put(&b)` took the address of a local slice and pushed it to heap — the classic `sync.Pool`-of-slices bug. The pool was never actually reusing anything.
- The variadic `(bs ...[]byte)` backing array at the `util.CacheKeyBytes` call site escaped because `CacheKeyBytes` was too complex to inline, so the compiler conservatively heap-allocated the `[][]byte`.

## Design

`CacheKeyBuilder` pools a `maphash.Hash` and writes a 4-byte little-endian length prefix before each field. A package-level `cacheKeySeed` is set once in the pool's `New` function so that every builder drawn from the pool produces consistent keys within a process, while still being randomized at startup for hash-flooding resistance.

`maphash` was chosen over `hash/crc64` for three reasons:

1. It is designed as a hash-table hash, not an error-detection code.
2. It is seeded with `maphash.MakeSeed()` at package init, giving fasthttpd hash-flooding resistance against adversarial HTTP paths (crc64 is linear and trivially floodable).
3. Its native `WriteString` keeps the string path zero-copy without pulling in `unsafe`.

`CacheKeyOf` and `CacheKeyOfString` are single-field shortcuts that stack-allocate a `maphash.Hash` and bypass the pool — ideal for callers like `accesslog` that hash a single `addr` per request.

## Migrations

- **`pkg/route/route.go`**: drop the broken `rs.intBuf` `sync.Pool`, the `acquireIntBuf` / `releaseIntBuf` helpers, and the `\0` separator. The offset now lives in a stack-allocated `[4]byte`, and `(offBuf, method, path)` are written to the builder as length-prefixed fields.
- **`pkg/logger/accesslog/accesslog.go`**: switch the single-field `addr` lookup from `CacheKeyString` to `CacheKeyOfString`.

The old `CacheKeyBytes`, `CacheKeyString`, `hash64Pool`, `acquireHash64`, `releaseHash64` are deleted, along with the `hash` and `hash/crc64` imports.

## Tests

- **`TestCacheKey_FieldSeparator`** asserts that `("ab","c")`, `("a","bc")`, and two more field splits produce distinct keys. This is the guarantee the old API could not make.
- **`TestCacheKey_ShortcutMatchesBuilder`** pins down that `CacheKeyOfString` and `CacheKeyOf` produce the same value as the builder driven with a single field, so callers can freely mix the two in the same cache.
- **`TestCacheKey`** updated to assert `Write` and `WriteString` produce the same key for equivalent inputs.

## Benchmarks

Measured on Apple M4 (`darwin/arm64`), `-benchtime=3s`, parallel.

### New focused benches (fixed-args, `ReportAllocs`)

```
BenchmarkCacheKeyBuilder_RouterKey-10   604811316    5.919 ns/op    0 B/op    0 allocs/op
BenchmarkCacheKeyOfString-10           1000000000    1.269 ns/op    0 B/op    0 allocs/op
```

### `BenchmarkCachedRoutes_*` (end-to-end router cache lookup)

| bench | before | after |
|---|---|---|
| `Equal`  | 189.2 ns/op, **25 B/op, 2 allocs/op** | 184.4 ns/op, **0 B/op, 0 allocs/op** |
| `Prefix` | 184.2 ns/op, **25 B/op, 2 allocs/op** | 185.2 ns/op, **0 B/op, 0 allocs/op** |
| `Regexp` | 184.9 ns/op, **25 B/op, 2 allocs/op** | 185.5 ns/op, **0 B/op, 0 allocs/op** |

The router cache lookup path is now fully allocation-free with no change in latency.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` — all packages pass, no race warnings
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -bench=CacheKeyBuilder -benchmem ./pkg/util/` — 0 allocs
- [x] `go test -bench=CachedRoutes -benchmem ./pkg/route/` — 0 allocs