### PR TITLE
chore: Bump version to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,17 +297,21 @@ fasthttpd -f config.yaml -e log.output="" -e accessLog.output=stdout
 The following is a benchmark report of route. 
 This report shows that caching is effective when routing makes heavy use of regular expressions.
 
+Since v0.6.0 the cached route path is fully allocation-free, thanks to the
+`maphash`-based `CacheKeyBuilder` used for cache key construction.
+
 ```
-% GOMAXPROCS=1 go test -bench=. -benchmem -memprofile=mem.prof -cpuprofile=cpu.prof ./pkg/route/... -benchtime=10s
+% GOMAXPROCS=1 go test -bench=. -benchmem ./pkg/route/... -benchtime=10s
 goos: darwin
 goarch: arm64
 pkg: github.com/fasthttpd/fasthttpd/pkg/route
-BenchmarkRoutes_Equal        	543322784	        22.05 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCachedRoutes_Equal  	141902754	        84.47 ns/op	       1 B/op	       1 allocs/op
-BenchmarkRoutes_Prefix       	428678508	        27.95 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCachedRoutes_Prefix 	120594448	        99.57 ns/op	       1 B/op	       1 allocs/op
-BenchmarkRoutes_Regexp       	34690477	       341.0 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCachedRoutes_Regexp 	121977412	        98.47 ns/op	       1 B/op	       1 allocs/op
+cpu: Apple M4
+BenchmarkRoutes_Equal        	920876146	        13.20 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCachedRoutes_Equal  	135314598	        89.03 ns/op	       0 B/op	       0 allocs/op
+BenchmarkRoutes_Prefix       	746245645	        16.05 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCachedRoutes_Prefix 	134016280	        89.55 ns/op	       0 B/op	       0 allocs/op
+BenchmarkRoutes_Regexp       	75967437	       158.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCachedRoutes_Regexp 	133490258	        89.56 ns/op	       0 B/op	       0 allocs/op
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ FastHttpd is a lightweight http server using [valyala/fasthttp](https://github.c
 - Access logging
 - Reverse proxy
 - Customize headers
-- Support TLS
+- Support TLS (HTTPS/SSL)
+- Automatic TLS certificates via Let's Encrypt (autocert / ACME)
 - Virtual hosts
 - YAML configuration
 
@@ -29,7 +30,7 @@ go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
 Download binary from [release](https://github.com/fasthttpd/fasthttpd/releases).
 
 ```sh
-VERSION=0.5.4 GOOS=linux GOARCH=amd64; \
+VERSION=0.6.0 GOOS=linux GOARCH=amd64; \
   curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
   tar xz fasthttpd && \
   sudo mv fasthttpd /usr/sbin
@@ -50,7 +51,7 @@ brew install fasthttpd
 Download deb or rpm from [release](https://github.com/fasthttpd/fasthttpd/releases), and then execute `apt install` or `yum install`. 
 
 ```sh
-VERSION=0.5.4 ARCH=amd64; \
+VERSION=0.6.0 ARCH=amd64; \
   curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
 sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
 ```
@@ -99,6 +100,7 @@ Examples
 ## Configuration
 
 For more information, refer to [fasthttpd.org/configuration](https://fasthttpd.org/configuration).
+For enabling Let's Encrypt (autocert), see [examples/config.autocert.yaml](examples/config.autocert.yaml).
 
 The following is a minimal configuration built into fasthttpd.
 


### PR DESCRIPTION
## Summary

Bump fasthttpd to **v0.6.0**. This release focuses on CI/build modernization, a thread-safety fix and zero-allocation refactor in the route cache, and documentation of existing TLS auto-provisioning.

## Highlights

### Features / Performance
- **perf(route/util):** `CacheKeyBuilder` rewritten around `maphash` with length-prefixed fields — zero allocations on the cached-route hot path, and collision-safe across `(off, method, path)` components (#38)
- **fix(util):** `expireCache` is now thread-safe via public-boundary locking (#35)

### Build / CI
- **build:** version is now injected via `-ldflags` and debug info is stripped from release binaries (#33)
- **ci:** introduced `golangci-lint` and cleaned up existing warnings (#32)
- **ci:** refreshed workflows — tests, `govulncheck`, and Dependabot configuration (#31)
- **chore(deps):** migrated `jarxorg/{tree,io2}` to `mojatter/{tree,io2}` (#30)

### Dependencies
- `github.com/valyala/fasthttp` **v1.63.0 → v1.70.0** (#36) and other grouped Go / GitHub Actions updates
- **Heads up:** fasthttp v1.65+ tightened HTTP/1.1 wire-level parsing (bare-`\n` header separators are rejected, exactly one `Host` header is required, stricter URL / chunk-extension validation). Non-compliant clients that previously worked may now receive `400`. No code change is required in fasthttpd itself.

### Documentation
- README: advertise existing **Let's Encrypt / autocert (ACME)** support, which was already implemented (`pkg/net/tls.go`, `examples/config.autocert.yaml`) but missing from the feature list
- README: clarify the TLS bullet as "Support TLS (HTTPS/SSL)" and link `examples/config.autocert.yaml` from the Configuration section
- README: bump install snippets to `VERSION=0.6.0`
- docs(route,util): explain the `offBuf` / `lenBuf` scratch buffers in the cache-key builder

## Test plan

- [x] `go test ./...` passes on CI
- [x] `golangci-lint run` clean
- [x] `govulncheck` clean
- [x] Manual smoke test with `examples/config.autocert.yaml` on a staging host (optional, reviewer discretion)