### PR TITLE
docs(readme): Note fasthttp compatibility version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 FastHttpd is a lightweight http server using [valyala/fasthttp](https://github.com/valyala/fasthttp).
 
+> FastHttpd and fasthttp are versioned independently. FastHttpd **v0.6.0** is built against fasthttp **v1.70.0**.
+
 ## Features
 
 - Serve static files


### PR DESCRIPTION
## Summary

- Clarify in the README that fasthttpd and fasthttp are versioned independently
- Record that fasthttpd **v0.6.0** is built against fasthttp **v1.70.0**, so readers can tell at a glance which upstream behavior to expect (useful in light of the HTTP/1.1 parser tightening in fasthttp v1.65+)

## Test plan

- [x] Rendered README reads naturally on GitHub