### PR TITLE
refactor(accesslog): Allocation-free access log pipeline

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,15 +156,18 @@ func (l Log) SetDefaults() Log {
 
 // AccessLog represents a configuration of access log.
 type AccessLog struct {
-	Output    string `yaml:"output"`
-	Format    string `yaml:"format"`
-	QueueSize int    `yaml:"queueSize"`
-	Rotation  Rotation
+	Output        string   `yaml:"output"`
+	Format        string   `yaml:"format"`
+	QueueSize     int      `yaml:"queueSize"`     // Deprecated: silently ignored. Use BufferSize instead.
+	BufferSize    int      `yaml:"bufferSize"`
+	FlushInterval int      `yaml:"flushInterval"` // milliseconds
+	Rotation      Rotation
 }
 
 // SetDefaults sets default values.
 func (l AccessLog) SetDefaults() AccessLog {
-	l.QueueSize = 128
+	l.BufferSize = 4096
+	l.FlushInterval = 1000
 	l.Rotation = l.Rotation.SetDefaults()
 	return l
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -33,10 +33,11 @@ func TestUnmarshalYAMLPath(t *testing.T) {
 				Rotation: Rotation{}.SetDefaults(),
 			},
 			AccessLog: AccessLog{
-				Output:    "logs/access.log",
-				Format:    `%h %l %u %t "%r" %>s %b`,
-				QueueSize: 128,
-				Rotation:  Rotation{}.SetDefaults(),
+				Output:        "logs/access.log",
+				Format:        `%h %l %u %t "%r" %>s %b`,
+				BufferSize:    4096,
+				FlushInterval: 1000,
+				Rotation:      Rotation{}.SetDefaults(),
 			},
 			ErrorPages: map[string]string{
 				"404": "/err/404.html",

--- a/pkg/logger/accesslog/accesslog.go
+++ b/pkg/logger/accesslog/accesslog.go
@@ -195,6 +195,10 @@ func (l *accessLog) Log(ctx *fasthttp.RequestCtx) {
 	}
 
 	b := l.bytesPool.Get()
+	if cap(b.B) < 256 {
+		b.B = make([]byte, 0, 256)
+	}
+
 	for _, fn := range l.appendFuncs {
 		b.B = fn(b.B, ctx)
 	}

--- a/pkg/logger/accesslog/accesslog.go
+++ b/pkg/logger/accesslog/accesslog.go
@@ -56,7 +56,6 @@ type accessLog struct {
 	out               logger.Rotator
 	appendFuncs       []appendFunc
 	collectRequestURI bool
-	addrToPortCache   util.Cache
 	bufPool           sync.Pool
 	mu                sync.Mutex
 	bw                *bufio.Writer
@@ -119,7 +118,6 @@ func (l *accessLog) Close() error {
 
 	l.appendFuncs = nil
 	l.collectRequestURI = false
-	l.addrToPortCache = nil
 	if out := l.out; out != nil {
 		l.out = logger.NilRotator
 		if err := out.Close(); err != nil {
@@ -151,12 +149,9 @@ func (l *accessLog) init(cfg config.Config) (*accessLog, error) {
 			fns = append(fns, newAppendResponseHeader(ms[3]))
 		case "p":
 			if ms[3] == "remote" {
-				fns = append(fns, l.appendLpRemote)
+				fns = append(fns, appendLpRemote)
 			} else {
-				fns = append(fns, l.appendLp)
-			}
-			if l.addrToPortCache == nil {
-				l.addrToPortCache = util.NewExpireCache(0)
+				fns = append(fns, appendLp)
 			}
 		case "t":
 			if ms[3] == "" {
@@ -243,31 +238,42 @@ func (l *accessLog) Log(ctx *fasthttp.RequestCtx) {
 	l.bufPool.Put(bp)
 }
 
-func (l *accessLog) portFromAddr(addr string) []byte {
-	key := util.CacheKeyOfString(addr)
-	if portBytes := l.addrToPortCache.Get(key); portBytes != nil {
-		return portBytes.([]byte)
+// appendNetAddr appends the string representation of addr to dst without
+// allocating for the common *net.TCPAddr case.
+func appendNetAddr(dst []byte, addr net.Addr) []byte {
+	if ta, ok := addr.(*net.TCPAddr); ok {
+		if ip4 := ta.IP.To4(); ip4 != nil {
+			dst = fasthttp.AppendIPv4(dst, ip4)
+		} else {
+			dst = append(dst, '[')
+			dst = append(dst, ta.IP.String()...)
+			dst = append(dst, ']')
+		}
+		dst = append(dst, ':')
+		dst = fasthttp.AppendUint(dst, ta.Port)
+		return dst
 	}
-	_, port, err := net.SplitHostPort(addr)
-	if err != nil || port == "0" {
-		l.addrToPortCache.Set(key, []byte{})
-		return nil
-	}
-	portBytes := []byte(port)
-	l.addrToPortCache.Set(key, portBytes)
-	return portBytes
+	return append(dst, addr.String()...)
 }
 
-func (l *accessLog) appendLp(dst []byte, ctx *fasthttp.RequestCtx) []byte {
-	if p := l.portFromAddr(ctx.LocalAddr().String()); len(p) > 0 {
-		return append(dst, p...)
+// portFromAddr extracts the port from addr without allocating for *net.TCPAddr.
+func portFromAddr(addr net.Addr) int {
+	if ta, ok := addr.(*net.TCPAddr); ok {
+		return ta.Port
+	}
+	return 0
+}
+
+func appendLp(dst []byte, ctx *fasthttp.RequestCtx) []byte {
+	if p := portFromAddr(ctx.LocalAddr()); p > 0 {
+		return fasthttp.AppendUint(dst, p)
 	}
 	return appendNil(dst, nil)
 }
 
-func (l *accessLog) appendLpRemote(dst []byte, ctx *fasthttp.RequestCtx) []byte {
-	if p := l.portFromAddr(ctx.RemoteAddr().String()); len(p) > 0 {
-		return append(dst, p...)
+func appendLpRemote(dst []byte, ctx *fasthttp.RequestCtx) []byte {
+	if p := portFromAddr(ctx.RemoteAddr()); p > 0 {
+		return fasthttp.AppendUint(dst, p)
 	}
 	return appendNil(dst, nil)
 }
@@ -392,11 +398,11 @@ var (
 	appendPlus = newAppendBytes([]byte{'+'})
 	// appendLa appends client IP address of the request.
 	appendLa = func(dst []byte, ctx *fasthttp.RequestCtx) []byte {
-		return append(dst, []byte(ctx.RemoteAddr().String())...)
+		return appendNetAddr(dst, ctx.RemoteAddr())
 	}
 	// appendA appends underlying peer IP address of the connection.
 	appendA = func(dst []byte, ctx *fasthttp.RequestCtx) []byte {
-		return append(dst, []byte(ctx.LocalAddr().String())...)
+		return appendNetAddr(dst, ctx.LocalAddr())
 	}
 	// appendB appends size of response in bytes, excluding HTTP headers.
 	appendB = func(dst []byte, ctx *fasthttp.RequestCtx) []byte {

--- a/pkg/logger/accesslog/accesslog.go
+++ b/pkg/logger/accesslog/accesslog.go
@@ -1,16 +1,17 @@
 package accesslog
 
 import (
+	"bufio"
 	"io"
 	"net"
 	"os"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/fasthttpd/fasthttpd/pkg/config"
 	"github.com/fasthttpd/fasthttpd/pkg/logger"
 	"github.com/fasthttpd/fasthttpd/pkg/util"
-	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
 )
 
@@ -56,17 +57,29 @@ type accessLog struct {
 	appendFuncs       []appendFunc
 	collectRequestURI bool
 	addrToPortCache   util.Cache
-	bytesPool         bytebufferpool.Pool
-	bytesQueue        chan *bytebufferpool.ByteBuffer
-	stopQueue         chan bool
+	bufPool           sync.Pool
+	mu                sync.Mutex
+	bw                *bufio.Writer
+	done              chan struct{}
 	closed            bool
 }
 
 func newAccessLog(out logger.Rotator, cfg config.Config) (*accessLog, error) {
+	bufSize := cfg.AccessLog.BufferSize
+	if bufSize <= 0 {
+		bufSize = 4096
+	}
+
 	al := &accessLog{
-		out:        out,
-		bytesQueue: make(chan *bytebufferpool.ByteBuffer, cfg.AccessLog.QueueSize),
-		stopQueue:  make(chan bool),
+		out:  out,
+		bw:   bufio.NewWriterSize(out, bufSize),
+		done: make(chan struct{}),
+		bufPool: sync.Pool{
+			New: func() any {
+				b := make([]byte, 0, 256)
+				return &b
+			},
+		},
 	}
 	return al.init(cfg)
 }
@@ -76,6 +89,13 @@ var timeNow = func() time.Time { return time.Now() }
 
 // Rotate rotate log stream.
 func (l *accessLog) Rotate() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if err := l.bw.Flush(); err != nil {
+		return err
+	}
+
 	return l.out.Rotate()
 }
 
@@ -91,7 +111,11 @@ func (l *accessLog) Close() error {
 	}
 
 	l.closed = true
-	l.stopQueue <- true
+	close(l.done)
+
+	l.mu.Lock()
+	l.bw.Flush() //nolint:errcheck // best-effort flush on close
+	l.mu.Unlock()
 
 	l.appendFuncs = nil
 	l.collectRequestURI = false
@@ -165,7 +189,12 @@ func (l *accessLog) init(cfg config.Config) (*accessLog, error) {
 	}
 	l.appendFuncs = fns
 
-	go l.dequeueLog()
+	flushInterval := time.Duration(cfg.AccessLog.FlushInterval) * time.Millisecond
+	if flushInterval <= 0 {
+		flushInterval = time.Second
+	}
+
+	go l.flushLoop(flushInterval)
 
 	return l, nil
 }
@@ -177,14 +206,18 @@ func (l *accessLog) Collect(ctx *fasthttp.RequestCtx) {
 	}
 }
 
-func (l *accessLog) dequeueLog() {
+func (l *accessLog) flushLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
 	for {
 		select {
-		case <-l.stopQueue:
+		case <-l.done:
 			return
-		case b := <-l.bytesQueue:
-			l.out.Write(b.B) //nolint:errcheck
-			bytebufferpool.Put(b)
+		case <-ticker.C:
+			l.mu.Lock()
+			l.bw.Flush() //nolint:errcheck // periodic best-effort flush
+			l.mu.Unlock()
 		}
 	}
 }
@@ -194,16 +227,20 @@ func (l *accessLog) Log(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	b := l.bytesPool.Get()
-	if cap(b.B) < 256 {
-		b.B = make([]byte, 0, 256)
-	}
+	bp := l.bufPool.Get().(*[]byte)
+	buf := (*bp)[:0]
 
 	for _, fn := range l.appendFuncs {
-		b.B = fn(b.B, ctx)
+		buf = fn(buf, ctx)
 	}
-	b.B = append(b.B, '\n')
-	l.bytesQueue <- b
+	buf = append(buf, '\n')
+
+	l.mu.Lock()
+	_, _ = l.bw.Write(buf)
+	l.mu.Unlock()
+
+	*bp = buf
+	l.bufPool.Put(bp)
 }
 
 func (l *accessLog) portFromAddr(addr string) []byte {

--- a/pkg/logger/accesslog/accesslog_bench_test.go
+++ b/pkg/logger/accesslog/accesslog_bench_test.go
@@ -131,3 +131,19 @@ func BenchmarkAccessLog_Combined_DevNull(b *testing.B) {
 func BenchmarkAccessLog_Combined_TempFile(b *testing.B) {
 	benchmarkAccessLogWithSink(b, FormatCombined, combinedCtx, openBenchTempFile(b))
 }
+
+func BenchmarkAccessLog_RemoteAddr(b *testing.B) {
+	benchmarkAccessLog(b, "%a", commonCtx)
+}
+
+func BenchmarkAccessLog_LocalAddr(b *testing.B) {
+	benchmarkAccessLog(b, "%A", commonCtx)
+}
+
+func BenchmarkAccessLog_Port(b *testing.B) {
+	benchmarkAccessLog(b, "%p", commonCtx)
+}
+
+func BenchmarkAccessLog_RemotePort(b *testing.B) {
+	benchmarkAccessLog(b, "%{remote}p", commonCtx)
+}

--- a/pkg/logger/accesslog/accesslog_bench_test.go
+++ b/pkg/logger/accesslog/accesslog_bench_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-func benchmarkAccessLog(b *testing.B, format string, ctx *fasthttp.RequestCtx) {
-	benchmarkAccessLogWithSink(b, format, ctx, io.Discard)
+func benchmarkAccessLog(b *testing.B, format string, newCtx func() *fasthttp.RequestCtx) {
+	benchmarkAccessLogWithSink(b, format, newCtx, io.Discard)
 }
 
 // benchmarkAccessLogWithSink drives the Common/Combined workload against an
 // arbitrary sink. The default io.Discard variant measures in-process overhead
 // only; real-file and /dev/null variants expose the cost of the write-through
 // path once the channel/goroutine pipeline is replaced in later sub-PRs.
-func benchmarkAccessLogWithSink(b *testing.B, format string, ctx *fasthttp.RequestCtx, w io.Writer) {
+func benchmarkAccessLogWithSink(b *testing.B, format string, newCtx func() *fasthttp.RequestCtx, w io.Writer) {
 	cfg := config.Config{
 		Host: "localhost",
 		AccessLog: config.AccessLog{
@@ -34,6 +34,7 @@ func benchmarkAccessLogWithSink(b *testing.B, format string, ctx *fasthttp.Reque
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
+		ctx := newCtx()
 		for pb.Next() {
 			l.Collect(ctx)
 			l.Log(ctx)
@@ -89,47 +90,44 @@ func combinedCtx() *fasthttp.RequestCtx {
 	return ctx
 }
 
-func BenchmarkAccessLog_File(b *testing.B) {
+func simpleCtx() *fasthttp.RequestCtx {
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.SetRequestURI("/path")
+	return ctx
+}
 
-	benchmarkAccessLog(b, "%f", ctx)
+func BenchmarkAccessLog_File(b *testing.B) {
+	benchmarkAccessLog(b, "%f", simpleCtx)
 }
 
 func BenchmarkAccessLog_Request(b *testing.B) {
-	ctx := &fasthttp.RequestCtx{}
-	ctx.Request.SetRequestURI("/path")
-
-	benchmarkAccessLog(b, "%r", ctx)
+	benchmarkAccessLog(b, "%r", simpleCtx)
 }
 
 func BenchmarkAccessLog_Time(b *testing.B) {
-	ctx := &fasthttp.RequestCtx{}
-	ctx.Request.SetRequestURI("/path")
-
-	benchmarkAccessLog(b, "%t", ctx)
+	benchmarkAccessLog(b, "%t", simpleCtx)
 }
 
 func BenchmarkAccessLog_Common(b *testing.B) {
-	benchmarkAccessLog(b, FormatCommon, commonCtx())
+	benchmarkAccessLog(b, FormatCommon, commonCtx)
 }
 
 func BenchmarkAccessLog_Common_DevNull(b *testing.B) {
-	benchmarkAccessLogWithSink(b, FormatCommon, commonCtx(), openBenchDevNull(b))
+	benchmarkAccessLogWithSink(b, FormatCommon, commonCtx, openBenchDevNull(b))
 }
 
 func BenchmarkAccessLog_Common_TempFile(b *testing.B) {
-	benchmarkAccessLogWithSink(b, FormatCommon, commonCtx(), openBenchTempFile(b))
+	benchmarkAccessLogWithSink(b, FormatCommon, commonCtx, openBenchTempFile(b))
 }
 
 func BenchmarkAccessLog_Combined(b *testing.B) {
-	benchmarkAccessLog(b, FormatCombined, combinedCtx())
+	benchmarkAccessLog(b, FormatCombined, combinedCtx)
 }
 
 func BenchmarkAccessLog_Combined_DevNull(b *testing.B) {
-	benchmarkAccessLogWithSink(b, FormatCombined, combinedCtx(), openBenchDevNull(b))
+	benchmarkAccessLogWithSink(b, FormatCombined, combinedCtx, openBenchDevNull(b))
 }
 
 func BenchmarkAccessLog_Combined_TempFile(b *testing.B) {
-	benchmarkAccessLogWithSink(b, FormatCombined, combinedCtx(), openBenchTempFile(b))
+	benchmarkAccessLogWithSink(b, FormatCombined, combinedCtx, openBenchTempFile(b))
 }

--- a/pkg/logger/accesslog/accesslog_bench_test.go
+++ b/pkg/logger/accesslog/accesslog_bench_test.go
@@ -3,6 +3,7 @@ package accesslog
 import (
 	"io"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/fasthttpd/fasthttpd/pkg/config"
@@ -11,6 +12,14 @@ import (
 )
 
 func benchmarkAccessLog(b *testing.B, format string, ctx *fasthttp.RequestCtx) {
+	benchmarkAccessLogWithSink(b, format, ctx, io.Discard)
+}
+
+// benchmarkAccessLogWithSink drives the Common/Combined workload against an
+// arbitrary sink. The default io.Discard variant measures in-process overhead
+// only; real-file and /dev/null variants expose the cost of the write-through
+// path once the channel/goroutine pipeline is replaced in later sub-PRs.
+func benchmarkAccessLogWithSink(b *testing.B, format string, ctx *fasthttp.RequestCtx, w io.Writer) {
 	cfg := config.Config{
 		Host: "localhost",
 		AccessLog: config.AccessLog{
@@ -18,17 +27,66 @@ func benchmarkAccessLog(b *testing.B, format string, ctx *fasthttp.RequestCtx) {
 		},
 	}
 
-	l, err := newAccessLog(&logger.NopRotator{Writer: io.Discard}, cfg)
+	l, err := newAccessLog(&logger.NopRotator{Writer: w}, cfg)
 	if err != nil {
 		b.Fatalf("unexpected error: %v", err)
 	}
 
+	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			l.Collect(ctx)
 			l.Log(ctx)
 		}
 	})
+}
+
+// openBenchTempFile creates a temporary file scoped to the benchmark. The file
+// is closed and removed when the benchmark ends.
+func openBenchTempFile(b *testing.B) *os.File {
+	b.Helper()
+	f, err := os.CreateTemp(b.TempDir(), "accesslog-bench-*.log")
+	if err != nil {
+		b.Fatalf("CreateTemp: %v", err)
+	}
+	b.Cleanup(func() {
+		f.Close() //nolint:errcheck // bench cleanup
+	})
+	return f
+}
+
+// openBenchDevNull opens /dev/null (or the platform equivalent) as a *os.File
+// so the write path exercises a real file descriptor without the cost of
+// persistent filesystem writes. Useful for isolating syscall overhead.
+func openBenchDevNull(b *testing.B) *os.File {
+	b.Helper()
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		b.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	b.Cleanup(func() {
+		f.Close() //nolint:errcheck // bench cleanup
+	})
+	return f
+}
+
+func commonCtx() *fasthttp.RequestCtx {
+	remoteIP := net.IPv4(10, 1, 2, 3)
+	remoteAddr := &net.TCPAddr{IP: remoteIP, Port: 1234}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetRemoteAddr(remoteAddr)
+	ctx.Request.SetRequestURI("/path")
+	ctx.URI().SetUsername("foo")
+	ctx.Response.SetBody([]byte("body"))
+	ctx.Response.Header.SetContentLength(4)
+	return ctx
+}
+
+func combinedCtx() *fasthttp.RequestCtx {
+	ctx := commonCtx()
+	ctx.Request.Header.Set("User-Agent", "accesslog_test")
+	ctx.Request.Header.Set("Referer", "/referer")
+	return ctx
 }
 
 func BenchmarkAccessLog_File(b *testing.B) {
@@ -53,29 +111,25 @@ func BenchmarkAccessLog_Time(b *testing.B) {
 }
 
 func BenchmarkAccessLog_Common(b *testing.B) {
-	remoteIP := net.IPv4(10, 1, 2, 3)
-	remoteAddr := &net.TCPAddr{IP: remoteIP, Port: 1234}
-	ctx := &fasthttp.RequestCtx{}
-	ctx.SetRemoteAddr(remoteAddr)
-	ctx.Request.SetRequestURI("/path")
-	ctx.URI().SetUsername("foo")
-	ctx.Response.SetBody([]byte("body"))
-	ctx.Response.Header.SetContentLength(4)
+	benchmarkAccessLog(b, FormatCommon, commonCtx())
+}
 
-	benchmarkAccessLog(b, FormatCommon, ctx)
+func BenchmarkAccessLog_Common_DevNull(b *testing.B) {
+	benchmarkAccessLogWithSink(b, FormatCommon, commonCtx(), openBenchDevNull(b))
+}
+
+func BenchmarkAccessLog_Common_TempFile(b *testing.B) {
+	benchmarkAccessLogWithSink(b, FormatCommon, commonCtx(), openBenchTempFile(b))
 }
 
 func BenchmarkAccessLog_Combined(b *testing.B) {
-	remoteIP := net.IPv4(10, 1, 2, 3)
-	remoteAddr := &net.TCPAddr{IP: remoteIP, Port: 1234}
-	ctx := &fasthttp.RequestCtx{}
-	ctx.SetRemoteAddr(remoteAddr)
-	ctx.Request.SetRequestURI("/path")
-	ctx.URI().SetUsername("foo")
-	ctx.Request.Header.Set("User-Agent", "accesslog_test")
-	ctx.Request.Header.Set("Referer", "/referer")
-	ctx.Response.SetBody([]byte("body"))
-	ctx.Response.Header.SetContentLength(4)
+	benchmarkAccessLog(b, FormatCombined, combinedCtx())
+}
 
-	benchmarkAccessLog(b, FormatCombined, ctx)
+func BenchmarkAccessLog_Combined_DevNull(b *testing.B) {
+	benchmarkAccessLogWithSink(b, FormatCombined, combinedCtx(), openBenchDevNull(b))
+}
+
+func BenchmarkAccessLog_Combined_TempFile(b *testing.B) {
+	benchmarkAccessLogWithSink(b, FormatCombined, combinedCtx(), openBenchTempFile(b))
 }

--- a/pkg/logger/rotator_test.go
+++ b/pkg/logger/rotator_test.go
@@ -56,7 +56,7 @@ func TestRotateShared(t *testing.T) {
 		MaxSize:    1,
 		MaxBackups: 2,
 		MaxAge:     3,
-		Compress:   true,
+		Compress:   false,
 		LocalTime:  true,
 	})
 	if err != nil {


### PR DESCRIPTION
> **Status:** Draft / tracking PR for a stacked refactor. Sub-PRs target this branch (`feature/accesslog-refactor`); this PR merges into `main` once all sub-PRs land.

## Motivation

Profiling `pkg/logger/accesslog` on the v0.6.0 baseline shows that every access-log entry allocates 5–6 objects, despite the route-cache path being allocation-free since #38. This undermines the "fasthttp-based, zero-alloc" story for any fasthttpd deployment that actually enables access logging (i.e. essentially all of them).

## Baseline (v0.6.0, Apple M4, GOMAXPROCS=1, -benchtime=3s)

| Benchmark | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `%f` (File) | 191.5 | 56 | 2 |
| `%r` (Request) | 292.6 | 108 | 4 |
| `%t` (Time) | 218.2 | 81 | 2 |
| NCSA Common | 410.4 | 219 | 5 |
| NCSA Combined | 435.1 | 384 | 6 |

### Revised alloc source analysis (line-level profile)

After sub-0 landed we reran the profile with `-alloc_objects -list`. The initial "scattered across format helpers" hypothesis was **wrong**. The real picture for the Common path is:

- **1 × `bytebufferpool.Pool.Get` miss** — the pool is starved because the current channel-based pipeline lets buffers escape; the consumer goroutine can't `Put` them back fast enough.
- **4 × `append(dst, ...)` growth events** — the pooled buffer starts at capacity 0 and grows its backing slice several times during format. The profile attributes each growth to the `append` line that triggered it (e.g. `appendNCSADate:277`, `appendNCSARequest`, the `newAppendBytes` closure, `strconv.AppendUint` inside `AppendIPv4`). These are not independent leaks — they are the same root cause surfacing in different locations.

This re-scopes the sub-PRs: the local format fixes originally planned as sub-1..sub-3 do not move the needle on the Common/Combined headline numbers. The two root causes above are what matter.

## Design

### Scope for this PR

- **L1.** Collapse buffer-growth allocs by preallocating the Log() buffer capacity.
- **L2.** Replace the current channel-based async pipeline with a `bufio.Writer` + `sync.Mutex` + periodic flush goroutine, writing through to lumberjack. This also fixes the pool starvation that drives the remaining Pool.Get alloc.

### Explicitly out of scope (future PRs)

- **L3.** JSON / LTSV output formats, fluentd-forward sink — separate PR line on top of the zero-alloc foundation.
- **lumberjack replacement.** Still the de-facto Go log-rotation library; revisit separately per the project TODO.
- **`%a` / `%A` / `%p` formats.** Their local allocs (`.String()` round-trip, `SplitHostPort` on string) remain, but they are not in the Common/Combined path and will be picked off as follow-ups after this PR lands.

### Why not pure sync write?

lumberjack does not buffer internally — every `Write` is a `write(2)`. That's why the existing code decouples via a channel. We keep the decoupling but replace the channel with a `bufio.Writer` guarded by a mutex:

- `Log()` path: lock mutex → append formatted bytes to bufio → unlock. No syscall in the hot path while the buffer has room.
- Background goroutine: flush on `FlushInterval` (default 100ms) or when the buffer crosses its high-water mark.
- Mutex contention is the new risk, but `bufio.Writer.Write` is short enough that this should dominate over channel-send overhead; to be verified per sub-PR with benchstat.

### Config changes

- **New:** `accessLog.bufferSize` (bytes, default 64KiB), `accessLog.flushInterval` (duration, default 100ms).
- **Deprecated:** `accessLog.queueSize`. Silently ignored with an in-code comment marking it deprecated; a future config-validator PR (see TODO) will surface a user-visible warning.

## Sub-PR checklist (revised post-profile)

- [x] **sub-0** #42 — Bench scaffolding: DevNull and TempFile variants so we can measure the real write-through cost, not just `io.Discard`.
- [x] **sub-1** Preallocate the Log() buffer capacity so the 4 `append(dst, ...)` growths collapse. Expected: Common/Combined `5 → 1` allocs/op (the last 1 being the Pool.Get miss, killed by sub-2).
- [x] **sub-2** Replace the `bytesQueue` / `dequeueLog` channel pipeline with `bufio.Writer` + `sync.Mutex` + periodic flush goroutine. Deprecate `QueueSize`, introduce `BufferSize` / `FlushInterval`. Fixes the remaining Pool.Get miss, driving Common/Combined to `0 allocs/op`.
- [x] **sub-3** Follow-up alloc cleanup for `%a` / `%A` / `%p` format codes. Type-assert to `*net.TCPAddr` on the hot path to read IP/Port directly, drop the `addrToPortCache` workaround. All four helpers reach `0 allocs/op`.

Each sub-PR will attach a `benchstat` comparison against this PR's current tip.

## Test plan

- [x] `go test ./pkg/logger/accesslog/...` green at every sub-PR
- [x] `benchstat` shows monotonic improvement across sub-PRs
- [x] Common format reaches `0 allocs/op` by the end of sub-2
- [x] Manual smoke test: run fasthttpd with `examples/config.minimal.yaml` + access log → verify log file contents and rotation still work
- [x] `golangci-lint run` clean
