### PR TITLE
feat(accesslog): Add LTSV output format preset

### DIFF
--- a/pkg/logger/accesslog/accesslog.go
+++ b/pkg/logger/accesslog/accesslog.go
@@ -45,8 +45,11 @@ func NewAccessLog(cfg config.Config) (AccessLog, error) {
 
 // newAccessLog dispatches to the appropriate per-format constructor.
 func newAccessLog(out logger.Rotator, cfg config.Config) (*accessLog, error) {
-	if cfg.AccessLog.Format == FormatJSON {
+	switch cfg.AccessLog.Format {
+	case FormatJSON:
 		return newJSONAccessLog(out, cfg)
+	case FormatLTSV:
+		return newLTSVAccessLog(out, cfg)
 	}
 	return newNCSAAccessLog(out, cfg)
 }

--- a/pkg/logger/accesslog/accesslog_bench_test.go
+++ b/pkg/logger/accesslog/accesslog_bench_test.go
@@ -159,3 +159,15 @@ func BenchmarkAccessLog_JSON_DevNull(b *testing.B) {
 func BenchmarkAccessLog_JSON_TempFile(b *testing.B) {
 	benchmarkAccessLogWithSink(b, FormatJSON, combinedCtx, openBenchTempFile(b))
 }
+
+func BenchmarkAccessLog_LTSV(b *testing.B) {
+	benchmarkAccessLog(b, FormatLTSV, combinedCtx)
+}
+
+func BenchmarkAccessLog_LTSV_DevNull(b *testing.B) {
+	benchmarkAccessLogWithSink(b, FormatLTSV, combinedCtx, openBenchDevNull(b))
+}
+
+func BenchmarkAccessLog_LTSV_TempFile(b *testing.B) {
+	benchmarkAccessLogWithSink(b, FormatLTSV, combinedCtx, openBenchTempFile(b))
+}

--- a/pkg/logger/accesslog/ltsv.go
+++ b/pkg/logger/accesslog/ltsv.go
@@ -1,0 +1,111 @@
+package accesslog
+
+import (
+	"net"
+
+	"github.com/fasthttpd/fasthttpd/pkg/config"
+	"github.com/fasthttpd/fasthttpd/pkg/logger"
+	"github.com/valyala/fasthttp"
+)
+
+// FormatLTSV is the keyword that selects the preset LTSV output format.
+const FormatLTSV = "ltsv"
+
+// newLTSVAccessLog builds an *accessLog that writes records in the preset
+// LTSV format defined by appendLTSVLog.
+func newLTSVAccessLog(out logger.Rotator, cfg config.Config) (*accessLog, error) {
+	l := newSkeleton(out, cfg)
+	l.appendLine = appendLTSVLog
+	l.startFlushLoop(cfg)
+	return l, nil
+}
+
+// appendLTSVValue appends s to dst, replacing any TAB/LF/CR byte with a
+// single space so the result is safe as an LTSV field value. It is
+// allocation-free as long as dst has sufficient capacity.
+func appendLTSVValue(dst, s []byte) []byte {
+	for i := range len(s) {
+		c := s[i]
+		switch c {
+		case '\t', '\n', '\r':
+			dst = append(dst, ' ')
+		default:
+			dst = append(dst, c)
+		}
+	}
+	return dst
+}
+
+// appendHostIP appends the IP portion of addr to dst without port or
+// brackets, matching nginx's $remote_addr. It is allocation-free for the
+// common *net.TCPAddr case.
+func appendHostIP(dst []byte, addr net.Addr) []byte {
+	if ta, ok := addr.(*net.TCPAddr); ok {
+		if ip4 := ta.IP.To4(); ip4 != nil {
+			return fasthttp.AppendIPv4(dst, ip4)
+		}
+		return append(dst, ta.IP.String()...)
+	}
+	return dst
+}
+
+// appendLTSVLog writes one access log record to dst using the preset LTSV
+// schema. It is allocation-free for the common TCP path.
+//
+// The field list follows nginx/fluentd LTSV conventions:
+//
+//	time host forwardedfor user req scheme vhost status size
+//	reqsize reqtime_microsec referer ua
+//
+// host is the direct peer IP (without port), matching nginx's $remote_addr.
+// forwardedfor is the raw X-Forwarded-For header value. req combines method,
+// URI and protocol NCSA-style. Empty string fields are written as empty
+// values, not "-".
+func appendLTSVLog(dst []byte, ctx *fasthttp.RequestCtx) []byte {
+	dst = append(dst, "time:"...)
+	dst = appendISOTime(dst, ctx.Time())
+
+	dst = append(dst, "\thost:"...)
+	dst = appendHostIP(dst, ctx.RemoteAddr())
+
+	dst = append(dst, "\tforwardedfor:"...)
+	dst = appendLTSVValue(dst, ctx.Request.Header.PeekBytes(xForwardedForKey))
+
+	dst = append(dst, "\tuser:"...)
+	dst = appendLTSVValue(dst, ctx.Request.URI().Username())
+
+	dst = append(dst, "\treq:"...)
+	dst = appendLTSVValue(dst, ctx.Method())
+	dst = append(dst, ' ')
+	dst = appendLTSVValue(dst, ctx.RequestURI())
+	dst = append(dst, ' ')
+	dst = appendLTSVValue(dst, ctx.Request.Header.Protocol())
+
+	dst = append(dst, "\tscheme:"...)
+	dst = appendLTSVValue(dst, ctx.URI().Scheme())
+
+	dst = append(dst, "\tvhost:"...)
+	dst = appendLTSVValue(dst, ctx.Host())
+
+	dst = append(dst, "\tstatus:"...)
+	dst = fasthttp.AppendUint(dst, ctx.Response.StatusCode())
+
+	dst = append(dst, "\tsize:"...)
+	dst = fasthttp.AppendUint(dst, ctx.Response.Header.ContentLength())
+
+	dst = append(dst, "\treqsize:"...)
+	bytesIn := len(ctx.Request.Header.RawHeaders()) + len(ctx.Request.Body())
+	dst = fasthttp.AppendUint(dst, bytesIn)
+
+	dst = append(dst, "\treqtime_microsec:"...)
+	durationUs := int(timeNow().Sub(ctx.Time()).Microseconds())
+	dst = fasthttp.AppendUint(dst, durationUs)
+
+	dst = append(dst, "\treferer:"...)
+	dst = appendLTSVValue(dst, ctx.Request.Header.Referer())
+
+	dst = append(dst, "\tua:"...)
+	dst = appendLTSVValue(dst, ctx.Request.Header.UserAgent())
+
+	return dst
+}

--- a/pkg/logger/accesslog/ltsv_test.go
+++ b/pkg/logger/accesslog/ltsv_test.go
@@ -1,0 +1,236 @@
+package accesslog
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fasthttpd/fasthttpd/pkg/config"
+	"github.com/fasthttpd/fasthttpd/pkg/logger"
+	"github.com/mojatter/io2"
+	"github.com/valyala/fasthttp"
+)
+
+func TestAppendLTSVValue(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		in       string
+		want     string
+	}{
+		{caseName: "empty", in: "", want: ""},
+		{caseName: "ascii", in: "hello", want: "hello"},
+		{caseName: "tab", in: "a\tb", want: "a b"},
+		{caseName: "newline", in: "a\nb", want: "a b"},
+		{caseName: "cr", in: "a\rb", want: "a b"},
+		{caseName: "crlf", in: "a\r\nb", want: "a  b"},
+		{caseName: "mixed", in: "a\tb\nc\rd", want: "a b c d"},
+		{caseName: "colon_passthrough", in: "a:b", want: "a:b"},
+		{caseName: "space_passthrough", in: "a b c", want: "a b c"},
+		{caseName: "non_ascii_utf8", in: "日本語", want: "日本語"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got := string(appendLTSVValue(nil, []byte(tc.in)))
+			if got != tc.want {
+				t.Errorf("appendLTSVValue(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppendHostIP(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		addr     net.Addr
+		want     string
+	}{
+		{
+			caseName: "ipv4",
+			addr:     &net.TCPAddr{IP: net.IPv4(10, 1, 2, 3), Port: 51002},
+			want:     "10.1.2.3",
+		},
+		{
+			caseName: "ipv6",
+			addr:     &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 51002},
+			want:     "2001:db8::1",
+		},
+		{
+			caseName: "non_tcp",
+			addr:     &net.UnixAddr{Name: "/tmp/sock", Net: "unix"},
+			want:     "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got := string(appendHostIP(nil, tc.addr))
+			if got != tc.want {
+				t.Errorf("appendHostIP = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// parseLTSVLine parses a single LTSV line into a map. It mirrors the
+// semantics of TestAccessLog_LTSV and is not meant to be a full LTSV
+// implementation.
+func parseLTSVLine(line string) map[string]string {
+	out := map[string]string{}
+	for field := range strings.SplitSeq(line, "\t") {
+		k, v, ok := strings.Cut(field, ":")
+		if !ok {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func TestAccessLog_LTSV(t *testing.T) {
+	timeNowOrg := timeNow
+	defer func() { timeNow = timeNowOrg }()
+
+	// fasthttp.RequestCtx exposes Time() but no setter, so the request
+	// time is the zero value here. timeNow is mocked to make
+	// reqtime_microsec deterministic against that zero value.
+	timeNow = func() time.Time {
+		var zeroTime time.Time
+		return zeroTime.Add(1234 * time.Microsecond)
+	}
+	wantTime := "0001-01-01T00:00:00Z"
+
+	remoteAddr := &net.TCPAddr{IP: net.IPv4(10, 1, 2, 3), Port: 51002}
+
+	testCases := []struct {
+		caseName string
+		setup    func(ctx *fasthttp.RequestCtx)
+		want     map[string]string
+	}{
+		{
+			caseName: "minimal_get",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.SetRequestURI("/path?foo=bar")
+				ctx.Request.SetHost("localhost")
+				ctx.Response.SetBody([]byte("body"))
+				ctx.Response.Header.SetContentLength(4)
+			},
+			want: map[string]string{
+				"time":             wantTime,
+				"host":             "10.1.2.3",
+				"forwardedfor":     "",
+				"user":             "",
+				"req":              "GET /path?foo=bar HTTP/1.1",
+				"scheme":           "http",
+				"vhost":            "localhost",
+				"status":           "200",
+				"size":             "4",
+				"reqsize":          "0",
+				"reqtime_microsec": "1234",
+				"referer":          "",
+				"ua":               "",
+			},
+		},
+		{
+			caseName: "with_user_forwardedfor_ua",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.SetRequestURI("/")
+				ctx.Request.SetHost("example.com")
+				ctx.URI().SetUsername("alice")
+				ctx.Request.Header.Set("X-Forwarded-For", "203.0.113.7, 198.51.100.1")
+				ctx.Request.Header.Set("Referer", "http://example.com/prev")
+				ctx.Request.Header.Set("User-Agent", "Mozilla/5.0")
+			},
+			want: map[string]string{
+				"time":             wantTime,
+				"host":             "10.1.2.3",
+				"forwardedfor":     "203.0.113.7, 198.51.100.1",
+				"user":             "alice",
+				"req":              "GET / HTTP/1.1",
+				"scheme":           "http",
+				"vhost":            "example.com",
+				"status":           "200",
+				"size":             "0",
+				"reqsize":          "0",
+				"reqtime_microsec": "1234",
+				"referer":          "http://example.com/prev",
+				"ua":               "Mozilla/5.0",
+			},
+		},
+		{
+			caseName: "tab_in_header_replaced_with_space",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.SetRequestURI("/")
+				ctx.Request.SetHost("localhost")
+				// A literal TAB inside a header value must be sanitized
+				// so it does not break the LTSV line structure.
+				ctx.Request.Header.Set("User-Agent", "bad\tagent")
+			},
+			want: map[string]string{
+				"time":             wantTime,
+				"host":             "10.1.2.3",
+				"forwardedfor":     "",
+				"user":             "",
+				"req":              "GET / HTTP/1.1",
+				"scheme":           "http",
+				"vhost":            "localhost",
+				"status":           "200",
+				"size":             "0",
+				"reqsize":          "0",
+				"reqtime_microsec": "1234",
+				"referer":          "",
+				"ua":               "bad agent",
+			},
+		},
+	}
+
+	wroteCh := make(chan bool, 1)
+	buf := new(bytes.Buffer)
+	out := &io2.Delegator{
+		WriteFunc: func(p []byte) (n int, err error) {
+			n, err = buf.Write(p)
+			wroteCh <- true
+			return
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			buf.Reset()
+			ctx := &fasthttp.RequestCtx{}
+			ctx.SetRemoteAddr(remoteAddr)
+			tc.setup(ctx)
+
+			cfg := config.Config{AccessLog: config.AccessLog{
+				Format: FormatLTSV,
+				// Flush every Log() so wroteCh fires immediately.
+				BufferSize: 1,
+			}}
+			l, err := newAccessLog(&logger.NopRotator{Writer: out}, cfg)
+			if err != nil {
+				t.Fatalf("newAccessLog: %v", err)
+			}
+			defer l.Close()
+
+			l.Collect(ctx)
+			l.Log(ctx)
+			<-wroteCh
+
+			line := strings.TrimRight(buf.String(), "\n")
+			if strings.ContainsAny(line, "\n\r") {
+				t.Errorf("LTSV line contains unsanitized newline: %q", line)
+			}
+			got := parseLTSVLine(line)
+			// Every expected field must match exactly, and no
+			// unexpected fields should appear.
+			if len(got) != len(tc.want) {
+				t.Errorf("field count mismatch: got %d (%v), want %d", len(got), got, len(tc.want))
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("field %q = %q; want %q\nraw: %s", k, got[k], v, line)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ltsv` format keyword that selects a preset LTSV access log writer, complementing the existing NCSA and JSON presets.
- Shares the allocation-free pipeline from #41 and measures at the same performance as Combined NCSA.
- 13-field schema follows the nginx/fluentd LTSV convention:

  ```
  time host forwardedfor user req scheme vhost status size reqsize reqtime_microsec referer ua
  ```

## Design notes

- `host` is the direct peer IP (no port, no brackets), matching nginx's `$remote_addr`.
- `forwardedfor` is the raw `X-Forwarded-For` header value. The JSON preset's left-most-XFF derivation is intentionally not replicated to stay consistent with nginx conventions — users who want the derived client IP can use the JSON preset.
- `req` combines method, URI and protocol NCSA-style.
- Empty string fields are written as empty values, not `-`, following pure LTSV convention.
- `TAB`, `LF` and `CR` inside any string value are replaced with a single space (equivalent to nginx's `escape=default`) so a crafted header cannot break the LTSV line structure.

## Benchmarks (Apple M4)

| Preset | ns/op | B/op | allocs/op |
|---|---|---|---|
| Combined (NCSA) | 205.5 | 0 | 0 |
| JSON | 244.8 | 0 | 0 |
| **LTSV** | **206.6** | **0** | **0** |

LTSV matches Combined NCSA speed and is ~16% faster than JSON, while staying allocation-free.

## Test plan

- [x] \`go test ./pkg/logger/accesslog/...\` passes
- [x] \`golangci-lint run ./pkg/logger/accesslog/...\` reports 0 issues
- [x] \`go test -bench 'BenchmarkAccessLog_(Combined|JSON|LTSV)\$' -benchmem\` confirms 0 allocs/op
- [x] Integration test covers TAB-in-header sanitization