### PR TITLE
test: Add allocation benchmarks for filter and Content handler

### DIFF
--- a/pkg/filter/basicauth_test.go
+++ b/pkg/filter/basicauth_test.go
@@ -187,3 +187,48 @@ func TestBasicAuthFilter(t *testing.T) {
 		}
 	}
 }
+
+// newBenchBasicAuthFilter returns a BasicAuthFilter with a single user,
+// initialised and ready to authenticate against.
+func newBenchBasicAuthFilter(b *testing.B) *BasicAuthFilter {
+	b.Helper()
+	f := &BasicAuthFilter{
+		Realm: DefaultRealm,
+		Users: []*BasicAuthUser{
+			{Name: "foo", Secret: "bar"},
+		},
+	}
+	if err := f.init(); err != nil {
+		b.Fatalf("init: %v", err)
+	}
+	return f
+}
+
+// Each iteration resets the relevant ctx header so repeated calls in the
+// loop do not accumulate state across iterations.
+
+func BenchmarkBasicAuthFilter_Request_OK(b *testing.B) {
+	f := newBenchBasicAuthFilter(b)
+	ctx := &fasthttp.RequestCtx{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx.Request.Header.Reset()
+		ctx.Request.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
+		f.Request(ctx)
+	}
+}
+
+func BenchmarkBasicAuthFilter_Request_Unauthorized(b *testing.B) {
+	f := newBenchBasicAuthFilter(b)
+	ctx := &fasthttp.RequestCtx{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx.Request.Header.Reset()
+		ctx.Response.Header.Reset()
+		f.Request(ctx)
+	}
+}

--- a/pkg/filter/header_test.go
+++ b/pkg/filter/header_test.go
@@ -108,3 +108,62 @@ func TestHeaderFilter(t *testing.T) {
 		}
 	}
 }
+
+// newBenchHeaderFilter returns a HeaderFilter covering the mutation shapes
+// we want to measure for allocations: set, add and del on both the request
+// and response sides.
+func newBenchHeaderFilter(b *testing.B) Filter {
+	b.Helper()
+	f, err := NewHeaderFilter(tree.Map{
+		"request": tree.Map{
+			"set": tree.Map{
+				"X-Request-ID": tree.ToValue("bench"),
+			},
+			"del": tree.ToArrayValues("X-Forwarded-For"),
+		},
+		"response": tree.Map{
+			"set": tree.Map{
+				"Cache-Control": tree.ToValue("private, max-age=3600"),
+			},
+			"add": tree.Map{
+				"X-Frame-Options": tree.ToValue("DENY"),
+			},
+			"del": tree.ToArrayValues("Server"),
+		},
+	})
+	if err != nil {
+		b.Fatalf("NewHeaderFilter: %v", err)
+	}
+	return f
+}
+
+// Each iteration below resets the per-ctx header before invoking the
+// filter so that repeated Add mutations do not accumulate across
+// iterations. This mirrors production, where every request owns a fresh
+// RequestCtx.
+
+func BenchmarkHeaderFilter_Request(b *testing.B) {
+	f := newBenchHeaderFilter(b)
+	ctx := &fasthttp.RequestCtx{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx.Request.Header.Reset()
+		ctx.Request.Header.Set("X-Forwarded-For", "10.0.0.1")
+		f.Request(ctx)
+	}
+}
+
+func BenchmarkHeaderFilter_Response(b *testing.B) {
+	f := newBenchHeaderFilter(b)
+	ctx := &fasthttp.RequestCtx{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx.Response.Header.Reset()
+		ctx.Response.Header.Set("Server", "fasthttpd")
+		f.Response(ctx)
+	}
+}

--- a/pkg/handler/content_test.go
+++ b/pkg/handler/content_test.go
@@ -219,3 +219,78 @@ func TestContent_Handle(t *testing.T) {
 		}()
 	}
 }
+
+// newBenchContentHandler builds a Content handler backed by the supplied
+// config and asserts it constructs cleanly.
+func newBenchContentHandler(b *testing.B, cfg tree.Map) fasthttp.RequestHandler {
+	b.Helper()
+	fn, err := NewContentHandler(cfg, logger.NilLogger)
+	if err != nil {
+		b.Fatalf("NewContentHandler: %v", err)
+	}
+	return fn
+}
+
+// Each iteration resets the response and re-seeds the request URI before
+// invoking the handler, so repeated Set/Add calls do not accumulate state
+// across iterations.
+
+func BenchmarkContent_Handle_Unconditional(b *testing.B) {
+	fn := newBenchContentHandler(b, tree.Map{
+		"headers": tree.Map{
+			"Content-Type": tree.ToValue("text/plain"),
+		},
+		"body": tree.ToValue("hello"),
+	})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/hello")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx.Response.Reset()
+		fn(ctx)
+	}
+}
+
+func BenchmarkContent_Handle_PathCondition(b *testing.B) {
+	fn := newBenchContentHandler(b, tree.Map{
+		"body": tree.ToValue("default"),
+		"conditions": tree.Array{
+			tree.Map{
+				"path": tree.ToValue("/good-morning"),
+				"body": tree.ToValue("good morning"),
+			},
+		},
+	})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/good-morning")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx.Response.Reset()
+		fn(ctx)
+	}
+}
+
+func BenchmarkContent_Handle_QueryCondition(b *testing.B) {
+	fn := newBenchContentHandler(b, tree.Map{
+		"body": tree.ToValue("default"),
+		"conditions": tree.Array{
+			tree.Map{
+				"queryStringContains": tree.ToValue("a=1&c=3"),
+				"body":                tree.ToValue("matched"),
+			},
+		},
+	})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/hello?a=1&b=2&c=3")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx.Response.Reset()
+		fn(ctx)
+	}
+}


### PR DESCRIPTION
## Summary

Extend the allocation-measurement work that made the access log zero-alloc in #41 / #43 / #45 to cover the filter pipeline and the simple Content handler, so the next hot-path cleanups can be driven by data rather than guesses.

- Every registered filter (HeaderFilter, BasicAuthFilter) is already zero-alloc on the hot path.
- Content.Handle is clearly **not** zero-alloc (6-10 allocs/op depending on condition type). Optimization is intentionally out of scope for this PR; the baseline numbers here act as a regression guardrail for a follow-up.

Each benchmark resets the relevant ctx header (and the Content response) before every call so repeated Add/Set mutations do not accumulate across iterations, mirroring production where each request owns a fresh RequestCtx. \`Response.Reset()\` itself was verified to be zero-alloc at ~5 ns/op, so the remaining allocs are entirely attributable to the code under test.

FS, Proxy and Balancer handlers are deliberately excluded: their allocation behaviour is dominated by fasthttp internals or network I/O rather than code owned by this repository.

## Results (Apple M4, benchtime=500ms)

| Bench | ns/op | B/op | allocs/op |
|---|---|---|---|
| HeaderFilter_Request | 91.8 | 0 | **0** |
| HeaderFilter_Response | 106.1 | 0 | **0** |
| BasicAuthFilter_Request_OK | 58.7 | 0 | **0** |
| BasicAuthFilter_Request_Unauthorized | 61.3 | 0 | **0** |
| Content_Handle_Unconditional | 195.0 | 96 | **6** |
| Content_Handle_PathCondition | 180.2 | 144 | **9** |
| Content_Handle_QueryCondition | 247.3 | 160 | **10** |

## Test plan

- [x] \`go test ./pkg/filter/... ./pkg/handler/...\` passes
- [x] \`golangci-lint run ./pkg/filter/... ./pkg/handler/...\` reports 0 issues
- [x] \`go test -bench 'BenchmarkHeaderFilter|BenchmarkBasicAuthFilter|BenchmarkContent_Handle' -benchmem\` produces the numbers above