### PR TITLE
perf(util): Improve expire cache (allocs, max cap, constructor API)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -186,11 +186,16 @@ type Route struct {
 	NextIfNotFound           bool     `yaml:"nextIfNotFound"`
 }
 
-// RoutesCache represents a configuration of route cache.
+// RoutesCache represents a configuration of route cache. MaxEntries
+// caps the cache at a fixed number of entries; when zero or negative
+// the cache is unbounded (pre-existing behavior). When the cap is
+// reached, Set on a new key is dropped so that already-cached hot
+// paths survive adversarial unique-key floods.
 type RoutesCache struct {
-	Enable   bool `yaml:"enable"`
-	Expire   int  `yaml:"expire"`
-	Interval int  `yaml:"interval"`
+	Enable     bool `yaml:"enable"`
+	Expire     int  `yaml:"expire"`
+	Interval   int  `yaml:"interval"`
+	MaxEntries int  `yaml:"maxEntries"`
 }
 
 // UnmarshalYAMLPath decodes path as multi Config YAML documents file.

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -146,11 +146,11 @@ func NewRoutes(cfg config.Config) (*Routes, error) {
 	}
 	rs := &Routes{routes: routes}
 	if cfg.RoutesCache.Enable {
-		rs.cache = util.NewExpireCacheIntervalMax(
-			int64(cfg.RoutesCache.Expire),
-			int64(cfg.RoutesCache.Interval),
-			cfg.RoutesCache.MaxEntries,
-		)
+		rs.cache = util.NewCache(util.CacheConfig{
+			Expire:     int64(cfg.RoutesCache.Expire),
+			Interval:   int64(cfg.RoutesCache.Interval),
+			MaxEntries: cfg.RoutesCache.MaxEntries,
+		})
 		rs.cache.OnRelease(onResultReleased)
 	}
 	return rs, nil

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -146,9 +146,10 @@ func NewRoutes(cfg config.Config) (*Routes, error) {
 	}
 	rs := &Routes{routes: routes}
 	if cfg.RoutesCache.Enable {
-		rs.cache = util.NewExpireCacheInterval(
+		rs.cache = util.NewExpireCacheIntervalMax(
 			int64(cfg.RoutesCache.Expire),
 			int64(cfg.RoutesCache.Interval),
+			cfg.RoutesCache.MaxEntries,
 		)
 		rs.cache.OnRelease(onResultReleased)
 	}

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -106,79 +106,91 @@ func CacheKeyOfString(s string) CacheKey {
 
 // Cache is an interface that defines accessor of the cache.
 type Cache interface {
-	Get(key CacheKey) interface{}
-	Set(key CacheKey, value interface{})
+	Get(key CacheKey) any
+	Set(key CacheKey, value any)
 	Del(key CacheKey)
 	Len() int
 	// OnRelease sets a callback that will be called on the key is released.
-	OnRelease(cb func(key CacheKey, value interface{}))
+	OnRelease(cb func(key CacheKey, value any))
 }
 
 const (
-	// defaultExpire is 5 * 60 * 1000 ms (5 min)
-	defaultExpire = 5 * 60 * 1000
-	// defaultInterval is 60 * 1000 ms (1 min)
-	defaultInterval = 60 * 1000
+	// defaultCacheExpire is 5 * 60 * 1000 ms (5 min)
+	defaultCacheExpire = 5 * 60 * 1000
+	// defaultCacheInterval is 60 * 1000 ms (1 min)
+	defaultCacheInterval = 60 * 1000
+	// defaultCacheStoreSize is the initial map capacity used when the
+	// caller does not specify MaxEntries.
+	defaultCacheStoreSize = 1024
 )
 
-var expireCacheNow = func() int64 {
+// cacheNow returns the current time in milliseconds since the Unix
+// epoch. Tests swap it to inject a deterministic clock.
+var cacheNow = func() int64 {
 	return time.Now().UnixMilli()
 }
 
-type expireCacheValue struct {
-	value interface{}
+type cacheValue struct {
+	value any
 	peek  int64
 }
 
-type expireCache struct {
-	store     map[CacheKey]*expireCacheValue
+type cache struct {
+	store     map[CacheKey]*cacheValue
 	expire    int64
 	interval  int64
 	next      int64
 	max       int
 	mutex     sync.Mutex
-	onRelease func(key CacheKey, value interface{})
+	onRelease func(key CacheKey, value any)
 }
 
-var _ Cache = (*expireCache)(nil)
+var _ Cache = (*cache)(nil)
 
-// NewExpireCache returns a new cache with the specified expire (ms),
-// default interval 1 min, and no entry limit.
-func NewExpireCache(expire int64) Cache {
-	return NewExpireCacheIntervalMax(expire, 0, 0)
-}
-
-// NewExpireCacheInterval returns a new cache with the specified expire
-// (ms) and interval (ms), and no entry limit.
-func NewExpireCacheInterval(expire, interval int64) Cache {
-	return NewExpireCacheIntervalMax(expire, interval, 0)
-}
-
-// NewExpireCacheIntervalMax returns a new cache with the specified
-// expire (ms), interval (ms), and maxEntries.
+// CacheConfig configures a Cache produced by NewCache.
 //
-// If maxEntries is zero or negative the cache is unbounded. When the
-// cache has reached maxEntries, Set on a new key is dropped (the
-// existing entries are preserved); this prioritizes already-cached hot
-// paths over adversarial unique-key floods.
-func NewExpireCacheIntervalMax(expire, interval int64, maxEntries int) Cache {
-	if expire <= 0 {
-		expire = defaultExpire
+// All durations are in milliseconds. Zero (or negative) values for
+// Expire and Interval fall back to package defaults; a non-positive
+// MaxEntries means the cache is unbounded.
+type CacheConfig struct {
+	// Expire is the entry TTL in milliseconds. An entry whose peek
+	// timestamp is older than Expire is removed on the next eviction
+	// pass.
+	Expire int64
+	// Interval is the minimum gap, in milliseconds, between background
+	// eviction passes.
+	Interval int64
+	// MaxEntries caps the number of stored entries. When the cap is
+	// reached, Set on a new key is dropped (existing entries are
+	// preserved); this prioritizes already-cached hot paths over
+	// adversarial unique-key floods. Zero or negative means unbounded.
+	MaxEntries int
+}
+
+// NewCache returns a new Cache configured by cfg.
+func NewCache(cfg CacheConfig) Cache {
+	storeSize := cfg.MaxEntries
+	if storeSize <= 0 {
+		storeSize = defaultCacheStoreSize
 	}
-	if interval <= 0 {
-		interval = defaultInterval
+	c := &cache{
+		store:    make(map[CacheKey]*cacheValue, storeSize),
+		expire:   cfg.Expire,
+		interval: cfg.Interval,
+		max:      cfg.MaxEntries,
 	}
-	return &expireCache{
-		store:    make(map[CacheKey]*expireCacheValue, 256),
-		expire:   expire,
-		interval: interval,
-		next:     expireCacheNow() + interval,
-		max:      maxEntries,
+	if c.expire <= 0 {
+		c.expire = defaultCacheExpire
 	}
+	if c.interval <= 0 {
+		c.interval = defaultCacheInterval
+	}
+	c.next = cacheNow() + c.interval
+	return c
 }
 
 // Get returns the value mapped to the specified key and extends its expiration.
-func (c *expireCache) Get(key CacheKey) interface{} {
+func (c *cache) Get(key CacheKey) any {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -186,7 +198,7 @@ func (c *expireCache) Get(key CacheKey) interface{} {
 	if v == nil {
 		return nil
 	}
-	now := expireCacheNow()
+	now := cacheNow()
 	v.peek = now
 	c.scheduleEvictLocked(now)
 	return v.value
@@ -195,25 +207,25 @@ func (c *expireCache) Get(key CacheKey) interface{} {
 // Set stores the value with key. When a maxEntries cap is configured
 // and the cache already holds that many entries, Set on a new key is
 // dropped; existing keys can still be updated in place.
-func (c *expireCache) Set(key CacheKey, value interface{}) {
+func (c *cache) Set(key CacheKey, value any) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	now := expireCacheNow()
+	now := cacheNow()
 	if c.max > 0 && len(c.store) >= c.max {
 		if _, exists := c.store[key]; !exists {
 			c.scheduleEvictLocked(now)
 			return
 		}
 	}
-	c.store[key] = &expireCacheValue{
+	c.store[key] = &cacheValue{
 		value: value,
 		peek:  now,
 	}
 	c.scheduleEvictLocked(now)
 }
 
-func (c *expireCache) Del(key CacheKey) {
+func (c *cache) Del(key CacheKey) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -227,7 +239,7 @@ func (c *expireCache) Del(key CacheKey) {
 	}
 }
 
-func (c *expireCache) Len() int {
+func (c *cache) Len() int {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -238,7 +250,7 @@ func (c *expireCache) Len() int {
 // by Del or by the background eviction pass. Passing nil clears the
 // callback; while no callback is set, Del and eviction skip goroutine
 // dispatch entirely and leave the hot path free of scheduler churn.
-func (c *expireCache) OnRelease(cb func(key CacheKey, value interface{})) {
+func (c *cache) OnRelease(cb func(key CacheKey, value any)) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -248,7 +260,7 @@ func (c *expireCache) OnRelease(cb func(key CacheKey, value interface{})) {
 // scheduleEvictLocked decides whether the interval has elapsed and, if so,
 // arms the next interval and launches a background eviction goroutine.
 // The caller must hold c.mutex.
-func (c *expireCache) scheduleEvictLocked(now int64) {
+func (c *cache) scheduleEvictLocked(now int64) {
 	if now < c.next {
 		return
 	}
@@ -263,10 +275,10 @@ func (c *expireCache) scheduleEvictLocked(now int64) {
 // When no onRelease callback is registered the eviction pass skips
 // allocating the release list and dispatching goroutines, keeping the
 // default routesCache path free of per-tick scheduler churn.
-func (c *expireCache) evict(now int64) {
+func (c *cache) evict(now int64) {
 	type released struct {
 		k CacheKey
-		v interface{}
+		v any
 	}
 
 	c.mutex.Lock()

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -121,12 +121,9 @@ const (
 	defaultInterval = 60 * 1000
 )
 
-var (
-	expireCacheNow = func() int64 {
-		return time.Now().UnixMilli()
-	}
-	defaultOnRelease = func(key CacheKey, value interface{}) {}
-)
+var expireCacheNow = func() int64 {
+	return time.Now().UnixMilli()
+}
 
 type expireCacheValue struct {
 	value interface{}
@@ -138,21 +135,33 @@ type expireCache struct {
 	expire    int64
 	interval  int64
 	next      int64
+	max       int
 	mutex     sync.Mutex
 	onRelease func(key CacheKey, value interface{})
 }
 
 var _ Cache = (*expireCache)(nil)
 
-// NewExpireCache returns a new cache with the specified expire (ms) and
-// default interval 1 min.
+// NewExpireCache returns a new cache with the specified expire (ms),
+// default interval 1 min, and no entry limit.
 func NewExpireCache(expire int64) Cache {
-	return NewExpireCacheInterval(expire, 0)
+	return NewExpireCacheIntervalMax(expire, 0, 0)
 }
 
 // NewExpireCacheInterval returns a new cache with the specified expire
-// (ms) and interval (ms).
+// (ms) and interval (ms), and no entry limit.
 func NewExpireCacheInterval(expire, interval int64) Cache {
+	return NewExpireCacheIntervalMax(expire, interval, 0)
+}
+
+// NewExpireCacheIntervalMax returns a new cache with the specified
+// expire (ms), interval (ms), and maxEntries.
+//
+// If maxEntries is zero or negative the cache is unbounded. When the
+// cache has reached maxEntries, Set on a new key is dropped (the
+// existing entries are preserved); this prioritizes already-cached hot
+// paths over adversarial unique-key floods.
+func NewExpireCacheIntervalMax(expire, interval int64, maxEntries int) Cache {
 	if expire <= 0 {
 		expire = defaultExpire
 	}
@@ -160,11 +169,11 @@ func NewExpireCacheInterval(expire, interval int64) Cache {
 		interval = defaultInterval
 	}
 	return &expireCache{
-		store:     make(map[CacheKey]*expireCacheValue, 256),
-		expire:    expire,
-		interval:  interval,
-		next:      expireCacheNow() + interval,
-		onRelease: defaultOnRelease,
+		store:    make(map[CacheKey]*expireCacheValue, 256),
+		expire:   expire,
+		interval: interval,
+		next:     expireCacheNow() + interval,
+		max:      maxEntries,
 	}
 }
 
@@ -183,12 +192,20 @@ func (c *expireCache) Get(key CacheKey) interface{} {
 	return v.value
 }
 
-// Set stores the value with key.
+// Set stores the value with key. When a maxEntries cap is configured
+// and the cache already holds that many entries, Set on a new key is
+// dropped; existing keys can still be updated in place.
 func (c *expireCache) Set(key CacheKey, value interface{}) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	now := expireCacheNow()
+	if c.max > 0 && len(c.store) >= c.max {
+		if _, exists := c.store[key]; !exists {
+			c.scheduleEvictLocked(now)
+			return
+		}
+	}
 	c.store[key] = &expireCacheValue{
 		value: value,
 		peek:  now,
@@ -205,7 +222,9 @@ func (c *expireCache) Del(key CacheKey) {
 		return
 	}
 	delete(c.store, key)
-	go c.onRelease(key, v.value)
+	if c.onRelease != nil {
+		go c.onRelease(key, v.value)
+	}
 }
 
 func (c *expireCache) Len() int {
@@ -215,14 +234,14 @@ func (c *expireCache) Len() int {
 	return len(c.store)
 }
 
+// OnRelease registers a callback invoked when a key is removed either
+// by Del or by the background eviction pass. Passing nil clears the
+// callback; while no callback is set, Del and eviction skip goroutine
+// dispatch entirely and leave the hot path free of scheduler churn.
 func (c *expireCache) OnRelease(cb func(key CacheKey, value interface{})) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if cb == nil {
-		c.onRelease = defaultOnRelease
-		return
-	}
 	c.onRelease = cb
 }
 
@@ -240,6 +259,10 @@ func (c *expireCache) scheduleEvictLocked(now int64) {
 // evict walks c.store under the lock, removes entries whose peek is older
 // than c.expire, and fires onRelease callbacks outside the lock so that a
 // slow callback cannot block other cache operations.
+//
+// When no onRelease callback is registered the eviction pass skips
+// allocating the release list and dispatching goroutines, keeping the
+// default routesCache path free of per-tick scheduler churn.
 func (c *expireCache) evict(now int64) {
 	type released struct {
 		k CacheKey
@@ -247,14 +270,16 @@ func (c *expireCache) evict(now int64) {
 	}
 
 	c.mutex.Lock()
+	onRelease := c.onRelease
 	var toRelease []released
 	for k, v := range c.store {
 		if now-v.peek > c.expire {
 			delete(c.store, k)
-			toRelease = append(toRelease, released{k, v.value})
+			if onRelease != nil {
+				toRelease = append(toRelease, released{k, v.value})
+			}
 		}
 	}
-	onRelease := c.onRelease
 	c.mutex.Unlock()
 
 	for _, r := range toRelease {

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -92,16 +92,16 @@ func TestCacheKey_ShortcutMatchesBuilder(t *testing.T) {
 	}
 }
 
-func Test_expireCache(t *testing.T) {
-	expireCacheNowOrg := expireCacheNow
-	defer func() { expireCacheNow = expireCacheNowOrg }()
+func TestCache(t *testing.T) {
+	cacheNowOrg := cacheNow
+	defer func() { cacheNow = cacheNowOrg }()
 
 	now := int64(0)
-	expireCacheNow = func() int64 {
+	cacheNow = func() int64 {
 		return now
 	}
 
-	c := NewExpireCache(0).(*expireCache)
+	c := NewCache(CacheConfig{}).(*cache)
 	c.Set(CacheKeyOfString("key1"), "value1")
 	c.Set(CacheKeyOfString("key2"), "value2")
 	c.Set(CacheKeyOfString("key3"), "value3")
@@ -142,12 +142,12 @@ func Test_expireCache(t *testing.T) {
 	}
 }
 
-func Test_expireCache_OnRelease(t *testing.T) {
-	expireCacheNowOrg := expireCacheNow
-	defer func() { expireCacheNow = expireCacheNowOrg }()
+func TestCache_OnRelease(t *testing.T) {
+	cacheNowOrg := cacheNow
+	defer func() { cacheNow = cacheNowOrg }()
 
 	now := int64(0)
-	expireCacheNow = func() int64 {
+	cacheNow = func() int64 {
 		return now
 	}
 
@@ -155,8 +155,8 @@ func Test_expireCache_OnRelease(t *testing.T) {
 	key := CacheKeyOfString("key")
 	value := "value"
 
-	c := NewExpireCacheInterval(1, 1).(*expireCache)
-	c.OnRelease(func(k CacheKey, v interface{}) {
+	c := NewCache(CacheConfig{Expire: 1, Interval: 1}).(*cache)
+	c.OnRelease(func(k CacheKey, v any) {
 		if k != key || v != value {
 			t.Errorf("unexpected key value: %v %v", k, v)
 		}
@@ -174,17 +174,17 @@ func Test_expireCache_OnRelease(t *testing.T) {
 	c.OnRelease(nil)
 }
 
-// Test_expireCache_NoCallback ensures Del and evict remain functional
+// TestCache_NoCallback ensures Del and evict remain functional
 // (key removed, no panic) when OnRelease has never been set. This
 // guards the fast path that skips goroutine dispatch in that case.
-func Test_expireCache_NoCallback(t *testing.T) {
-	expireCacheNowOrg := expireCacheNow
-	defer func() { expireCacheNow = expireCacheNowOrg }()
+func TestCache_NoCallback(t *testing.T) {
+	cacheNowOrg := cacheNow
+	defer func() { cacheNow = cacheNowOrg }()
 
 	now := int64(0)
-	expireCacheNow = func() int64 { return now }
+	cacheNow = func() int64 { return now }
 
-	c := NewExpireCacheInterval(1, 1).(*expireCache)
+	c := NewCache(CacheConfig{Expire: 1, Interval: 1}).(*cache)
 	keyA := CacheKeyOfString("a")
 	keyB := CacheKeyOfString("b")
 	c.Set(keyA, "va")
@@ -210,17 +210,17 @@ func Test_expireCache_NoCallback(t *testing.T) {
 	t.Fatalf("evict did not drain store: size=%d", c.Len())
 }
 
-// Test_expireCache_MaxEntries verifies that the drop-new policy rejects
+// TestCache_MaxEntries verifies that the drop-new policy rejects
 // Set on a novel key when the cache is full, but still lets existing
 // keys be updated in place and frees room once entries are removed.
-func Test_expireCache_MaxEntries(t *testing.T) {
-	expireCacheNowOrg := expireCacheNow
-	defer func() { expireCacheNow = expireCacheNowOrg }()
+func TestCache_MaxEntries(t *testing.T) {
+	cacheNowOrg := cacheNow
+	defer func() { cacheNow = cacheNowOrg }()
 
 	now := int64(0)
-	expireCacheNow = func() int64 { return now }
+	cacheNow = func() int64 { return now }
 
-	c := NewExpireCacheIntervalMax(1000, 1000, 2).(*expireCache)
+	c := NewCache(CacheConfig{Expire: 1000, Interval: 1000, MaxEntries: 2}).(*cache)
 	keyA := CacheKeyOfString("a")
 	keyB := CacheKeyOfString("b")
 	keyC := CacheKeyOfString("c")
@@ -257,11 +257,11 @@ func Test_expireCache_MaxEntries(t *testing.T) {
 	}
 }
 
-// BenchmarkExpireCache_Get measures the steady-state cache-hit path,
+// BenchmarkCache_Get measures the steady-state cache-hit path,
 // which is the only branch reached during normal routesCache operation
 // after warmup. Must remain zero-alloc.
-func BenchmarkExpireCache_Get(b *testing.B) {
-	c := NewExpireCache(60_000)
+func BenchmarkCache_Get(b *testing.B) {
+	c := NewCache(CacheConfig{Expire: 60_000})
 	key := CacheKeyOfString("hit")
 	c.Set(key, "value")
 
@@ -272,10 +272,10 @@ func BenchmarkExpireCache_Get(b *testing.B) {
 	}
 }
 
-// BenchmarkExpireCache_Del_NoCallback guards the fast path that skips
+// BenchmarkCache_Del_NoCallback guards the fast path that skips
 // goroutine dispatch in Del when OnRelease is unset.
-func BenchmarkExpireCache_Del_NoCallback(b *testing.B) {
-	c := NewExpireCache(60_000)
+func BenchmarkCache_Del_NoCallback(b *testing.B) {
+	c := NewCache(CacheConfig{Expire: 60_000})
 	key := CacheKeyOfString("k")
 
 	b.ReportAllocs()
@@ -286,17 +286,17 @@ func BenchmarkExpireCache_Del_NoCallback(b *testing.B) {
 	}
 }
 
-// BenchmarkExpireCache_Evict_NoCallback forces an eviction pass over
+// BenchmarkCache_Evict_NoCallback forces an eviction pass over
 // expired entries with no callback registered. The fast path skips
 // allocating the release list and dispatching goroutines.
-func BenchmarkExpireCache_Evict_NoCallback(b *testing.B) {
-	expireCacheNowOrg := expireCacheNow
-	defer func() { expireCacheNow = expireCacheNowOrg }()
+func BenchmarkCache_Evict_NoCallback(b *testing.B) {
+	cacheNowOrg := cacheNow
+	defer func() { cacheNow = cacheNowOrg }()
 
 	now := int64(0)
-	expireCacheNow = func() int64 { return now }
+	cacheNow = func() int64 { return now }
 
-	c := NewExpireCacheInterval(1, 1_000_000).(*expireCache)
+	c := NewCache(CacheConfig{Expire: 1, Interval: 1_000_000}).(*cache)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -311,11 +311,11 @@ func BenchmarkExpireCache_Evict_NoCallback(b *testing.B) {
 	}
 }
 
-// BenchmarkExpireCache_Set_MaxReached exercises the drop-new branch of
+// BenchmarkCache_Set_MaxReached exercises the drop-new branch of
 // Set when the cap is saturated. It is expected to allocate nothing
 // because no wrapper is created.
-func BenchmarkExpireCache_Set_MaxReached(b *testing.B) {
-	c := NewExpireCacheIntervalMax(60_000, 60_000, 2)
+func BenchmarkCache_Set_MaxReached(b *testing.B) {
+	c := NewCache(CacheConfig{Expire: 60_000, Interval: 60_000, MaxEntries: 2})
 	c.Set(CacheKeyOfString("a"), "va")
 	c.Set(CacheKeyOfString("b"), "vb")
 	reject := CacheKeyOfString("c")

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -173,3 +173,156 @@ func Test_expireCache_OnRelease(t *testing.T) {
 	<-done
 	c.OnRelease(nil)
 }
+
+// Test_expireCache_NoCallback ensures Del and evict remain functional
+// (key removed, no panic) when OnRelease has never been set. This
+// guards the fast path that skips goroutine dispatch in that case.
+func Test_expireCache_NoCallback(t *testing.T) {
+	expireCacheNowOrg := expireCacheNow
+	defer func() { expireCacheNow = expireCacheNowOrg }()
+
+	now := int64(0)
+	expireCacheNow = func() int64 { return now }
+
+	c := NewExpireCacheInterval(1, 1).(*expireCache)
+	keyA := CacheKeyOfString("a")
+	keyB := CacheKeyOfString("b")
+	c.Set(keyA, "va")
+	c.Set(keyB, "vb")
+
+	c.Del(keyA)
+	if c.Len() != 1 {
+		t.Fatalf("unexpected size after Del: %d", c.Len())
+	}
+
+	// Force eviction of the remaining entry.
+	c.mutex.Lock()
+	c.scheduleEvictLocked(now + 2)
+	c.mutex.Unlock()
+
+	// evict runs in a goroutine; spin until store drains or time out.
+	for range 100 {
+		if c.Len() == 0 {
+			return
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+	t.Fatalf("evict did not drain store: size=%d", c.Len())
+}
+
+// Test_expireCache_MaxEntries verifies that the drop-new policy rejects
+// Set on a novel key when the cache is full, but still lets existing
+// keys be updated in place and frees room once entries are removed.
+func Test_expireCache_MaxEntries(t *testing.T) {
+	expireCacheNowOrg := expireCacheNow
+	defer func() { expireCacheNow = expireCacheNowOrg }()
+
+	now := int64(0)
+	expireCacheNow = func() int64 { return now }
+
+	c := NewExpireCacheIntervalMax(1000, 1000, 2).(*expireCache)
+	keyA := CacheKeyOfString("a")
+	keyB := CacheKeyOfString("b")
+	keyC := CacheKeyOfString("c")
+
+	c.Set(keyA, "va")
+	c.Set(keyB, "vb")
+	if c.Len() != 2 {
+		t.Fatalf("unexpected size after filling: %d", c.Len())
+	}
+
+	// New key beyond the cap is dropped.
+	c.Set(keyC, "vc")
+	if c.Len() != 2 {
+		t.Fatalf("cap violated: size=%d", c.Len())
+	}
+	if got := c.Get(keyC); got != nil {
+		t.Fatalf("dropped key unexpectedly cached: %v", got)
+	}
+
+	// Existing key can still be updated in place.
+	c.Set(keyA, "va2")
+	if got := c.Get(keyA); got != "va2" {
+		t.Fatalf("in-place update failed: %v", got)
+	}
+	if c.Len() != 2 {
+		t.Fatalf("in-place update grew cache: size=%d", c.Len())
+	}
+
+	// After Del the cap frees up and a new key fits.
+	c.Del(keyA)
+	c.Set(keyC, "vc")
+	if got := c.Get(keyC); got != "vc" {
+		t.Fatalf("unexpected value after freeing cap: %v", got)
+	}
+}
+
+// BenchmarkExpireCache_Get measures the steady-state cache-hit path,
+// which is the only branch reached during normal routesCache operation
+// after warmup. Must remain zero-alloc.
+func BenchmarkExpireCache_Get(b *testing.B) {
+	c := NewExpireCache(60_000)
+	key := CacheKeyOfString("hit")
+	c.Set(key, "value")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = c.Get(key)
+	}
+}
+
+// BenchmarkExpireCache_Del_NoCallback guards the fast path that skips
+// goroutine dispatch in Del when OnRelease is unset.
+func BenchmarkExpireCache_Del_NoCallback(b *testing.B) {
+	c := NewExpireCache(60_000)
+	key := CacheKeyOfString("k")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		c.Set(key, "v")
+		c.Del(key)
+	}
+}
+
+// BenchmarkExpireCache_Evict_NoCallback forces an eviction pass over
+// expired entries with no callback registered. The fast path skips
+// allocating the release list and dispatching goroutines.
+func BenchmarkExpireCache_Evict_NoCallback(b *testing.B) {
+	expireCacheNowOrg := expireCacheNow
+	defer func() { expireCacheNow = expireCacheNowOrg }()
+
+	now := int64(0)
+	expireCacheNow = func() int64 { return now }
+
+	c := NewExpireCacheInterval(1, 1_000_000).(*expireCache)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		// Populate a handful of entries, then force eviction at a
+		// timestamp past their expiry. evict takes the lock itself.
+		c.Set(CacheKeyOfString("a"), "va")
+		c.Set(CacheKeyOfString("b"), "vb")
+		c.Set(CacheKeyOfString("c"), "vc")
+		now += 10
+		c.evict(now)
+	}
+}
+
+// BenchmarkExpireCache_Set_MaxReached exercises the drop-new branch of
+// Set when the cap is saturated. It is expected to allocate nothing
+// because no wrapper is created.
+func BenchmarkExpireCache_Set_MaxReached(b *testing.B) {
+	c := NewExpireCacheIntervalMax(60_000, 60_000, 2)
+	c.Set(CacheKeyOfString("a"), "va")
+	c.Set(CacheKeyOfString("b"), "vb")
+	reject := CacheKeyOfString("c")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		c.Set(reject, "vc")
+	}
+}


### PR DESCRIPTION
## Summary
- Reduce `expireCache` allocations and goroutine churn on the hot path, and add a `MaxEntries` cap with drop-new policy to survive adversarial unique-key floods (c5ddb8a).
- Collapse the three telescoping `NewExpireCache*` constructors into a single `NewCache(CacheConfig)`. Since `util` has only one `Cache` impl, also strip `Expire` from internal names and switch `interface{}` to `any` (b2b6e24).
- `NewCache` uses `cfg.MaxEntries` as the map's initial capacity hint when positive, falling back to `defaultCacheStoreSize` (1024) otherwise.

## Test plan
- [x] `go test ./...`
- [x] `go test -run='^$' -bench=BenchmarkCache_ -benchmem ./pkg/util/` — `Get` and `Set_MaxReached` remain zero-alloc; `Del_NoCallback` / `Evict_NoCallback` match pre-refactor bytes/op.