### PR TITLE
docs: Move long-form reference content from README into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Examples
 
 ## Configuration
 
-For more information, refer to [fasthttpd.org/configuration](https://fasthttpd.org/configuration).
+For the full reference, see [docs/configuration.md](docs/configuration.md).
 For enabling Let's Encrypt (autocert), see [examples/config.autocert.yaml](examples/config.autocert.yaml).
 
 The following is a minimal configuration built into fasthttpd.
@@ -123,161 +123,7 @@ routes:
     handler: static
 ```
 
-The following is a configuration that uses most of the current FastHttpd features.
-
-```yaml
-host: localhost
-# NOTE: Define listen addr. It is supported ipv6 `[::1]:8080`
-listen: ':8080'
-root: ./public
-
-# Define fasthttp.Server settings.
-server:
-  name: fasthttpd
-  readBufferSize: 4096
-  writeBufferSize: 4096
-
-log:
-  output: logs/error.log
-  # NOTE: Flags supports date|time|microseconds
-  flags: [date, time]
-  rotation:
-    maxSize: 100
-
-accessLog:
-  output: logs/access.log
-  # NCSA-style format string, or 'json' / 'ltsv' to enable a structured preset.
-  format: '%h %l %u %t "%r" %>s %b'
-  rotation:
-    maxSize: 100
-    maxBackups: 14
-    maxAge: 28
-    compress: true
-    localTime: true
- 
-# Define custom error pages (x matches [0-9])
-errorPages:
-  '404': /err/404.html
-  '5xx': /err/5xx.html
-
-# Define named filters
-filters:
-
-  'auth':
-    type: basicAuth
-    users:
-      # WARNING: It is unsafe to define plain secrets. It is recommended for development use only.
-      - name: fast
-        secret: httpd
-    usersFile: ./users.yaml
-
-  'cache':
-    type: header
-    response:
-      set:
-        'Cache-Control': 'private, max-age=3600'
-
-# Define named handlers
-handlers:
-
-  'static':
-    type: fs
-    indexNames: [index.html]
-    generateIndexPages: false
-    compress: true
-    compressRoot: ./compressed
-
-  'static-overwrite':
-    type: fs
-    indexNames: [index.html]
-    root: ./public-overwrite
-  
-  'hello':
-    type: content
-    headers:
-      'Content-Type': 'text/plain; charset=utf-8'
-    body: Hello FastHttpd
-    conditions:
-      - path: '/hello/world'
-        body: Hello world
-      - queryStringContains: 'time=morning'
-        body: Good morning FastHttpd
-      - percentage: 10
-        body: 10% hit FastHttpd
-
-# The routes are processed in sequence and interrupted when the status or the handler is specified.
-routes:
-
-  # Allows GET, POST, HEAD only.
-  - methods: [PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH]
-    status: 405
-    statusMessage: 'Method not allowed'
-
-  # Route to /index.html.
-  - path: /
-    match: equal
-    handler: static
-
-  # Redirect to external url with status code 302.
-  - path: /redirect-external
-    match: equal
-    rewrite: http://example.com/
-    status: 302
-
-  # Redirect to internal uri with status code 302 and appendQueryString.
-  # If "GET /redirect-internal?name=value" is requested then it redirect to "/internal?foo=bar&name=value"
-  - path: /redirect-internal
-    match: equal
-    rewrite: /internal?foo=bar
-    rewriteAppendQueryString: true
-    status: 302
-  
-  # Route to static-overwrite resources using regexp.
-  - path: .*\.(js|css|jpg|png|gif|ico)$
-    match: regexp
-    filters: [cache]
-    methods: [GET, HEAD]
-    handler: static-overwrite
-    nextIfNotFound: true
-  
-  # Route to static resources using regexp.
-  - path: .*\.(js|css|jpg|png|gif|ico)$
-    match: regexp
-    filters: [cache]
-    methods: [GET, HEAD]
-    handler: static
-
-  # Rewrite the path and route to next (no handler and no status).
-  - path: ^/view/(.+)
-    match: regexp
-    rewrite: /view?id=$1
-
-  # Other requests are routed to hello with auth filter.
-  - filters: [auth]
-    handler: hello
-
-routesCache:
-  enable: true
-  expire: 60000
-
----
-
-host: localhost
-listen: ':8443'
-
-ssl:
-  certFile: ./ssl/localhost.crt
-  keyFile: ./ssl/localhost.key
-
-handlers:
-  'backend':
-    type: proxy
-    url: 'http://localhost:8080'
-
-routes:
-  - path: /
-    handler: backend
-```
+For a fuller configuration that exercises most of FastHttpd's features, see [docs/configuration.md](docs/configuration.md).
 
 ## Override configuration using edit option
 
@@ -319,103 +165,9 @@ BenchmarkCachedRoutes_Regexp 	133490258	        89.56 ns/op	       0 B/op	      
 
 ## Access log
 
-FastHttpd writes access logs through a `bufio.Writer` + `sync.Pool` pipeline that
-keeps the formatting hot path allocation-free for the classic NCSA format, the
-JSON preset and the LTSV preset.
+FastHttpd writes access logs through a `bufio.Writer` + `sync.Pool` pipeline that keeps the formatting hot path allocation-free for the classic NCSA format, the JSON preset and the LTSV preset.
 
-### NCSA format (default)
-
-`format` accepts an Apache-style format string. The default is the NCSA Common
-Log Format:
-
-```yaml
-accessLog:
-  output: logs/access.log
-  format: '%h %l %u %t "%r" %>s %b'
-```
-
-### JSON preset
-
-Set `format: json` to emit one JSON object per request with the following 15
-fields. The schema is flat `snake_case` so it can be ingested by jq, Loki,
-Elasticsearch, CloudWatch Logs Insights, and similar tools without
-transformation.
-
-```yaml
-accessLog:
-  output: logs/access.log
-  format: json
-  bufferSize: 4096
-  flushInterval: 1000
-```
-
-Sample output (one line, pretty-printed here for readability):
-
-```json
-{
-  "time": "2026-04-11T10:19:13+09:00",
-  "remote_addr": "10.1.2.3:51002",
-  "client_ip": "10.1.2.3",
-  "remote_user": "alice",
-  "method": "GET",
-  "uri": "/path?foo=bar",
-  "proto": "HTTP/1.1",
-  "scheme": "http",
-  "host": "example.com",
-  "status": 200,
-  "size": 1234,
-  "bytes_received": 0,
-  "duration_us": 412,
-  "referer": "https://example.com/",
-  "user_agent": "curl/8.7.1"
-}
-```
-
-Notes:
-
-- `time` is RFC 3339 with the local timezone offset.
-- `client_ip` is the left-most entry of the `X-Forwarded-For` header when
-  present, otherwise the IP portion of the connecting peer.
-- `duration_us` is integer microseconds; the unit is encoded in the key name
-  to avoid ambiguity.
-- `size` is the response body length and `bytes_received` is the request
-  header + body byte count.
-
-### LTSV preset
-
-Set `format: ltsv` to emit one [Labeled Tab-separated
-Values](http://ltsv.org/) record per request. The 13-field schema follows the
-nginx / fluentd LTSV convention, so existing parsers and log forwarders
-ingest it without configuration.
-
-```yaml
-accessLog:
-  output: logs/access.log
-  format: ltsv
-  bufferSize: 4096
-  flushInterval: 1000
-```
-
-Sample output (one line, wrapped here for readability):
-
-```
-time:2026-04-11T10:19:13+09:00	host:10.1.2.3	forwardedfor:	user:alice
-	req:GET /path?foo=bar HTTP/1.1	scheme:http	vhost:example.com
-	status:200	size:1234	reqsize:0	reqtime_microsec:412
-	referer:https://example.com/	ua:curl/8.7.1
-```
-
-Notes:
-
-- `host` is the direct peer IP (without port), matching nginx's `$remote_addr`.
-- `forwardedfor` is the raw `X-Forwarded-For` header value; unlike the JSON
-  preset, no left-most derivation is performed.
-- `req` combines the method, request URI and protocol NCSA-style.
-- Empty string fields are written as empty values, not `-`, following pure
-  LTSV convention.
-- Any `TAB`, `LF` or `CR` byte inside a string value is replaced with a
-  single space so a crafted header cannot break the LTSV line structure
-  (equivalent to nginx's `escape=default`).
+See [docs/access-log.md](docs/access-log.md) for format options, JSON / LTSV schema and field-level notes.
 
 ### Benchmark
 
@@ -430,11 +182,6 @@ BenchmarkAccessLog_Combined-10    17296656          209.6 ns/op       0 B/op    
 BenchmarkAccessLog_JSON-10        14670214          243.3 ns/op       0 B/op       0 allocs/op
 BenchmarkAccessLog_LTSV-10        17862510          201.7 ns/op       0 B/op       0 allocs/op
 ```
-
-## TODO
-
-- Support HTTP/3
-- Benchmark reports
 
 ## Third-party library licenses
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# FastHttpd Documentation
+
+A lightweight HTTP server built on [valyala/fasthttp](https://github.com/valyala/fasthttp).
+
+## Contents
+
+- [Getting started](getting-started.md) — minimal configuration and first run
+- [Installation](installation.md) — Go install, binary download, Homebrew, apt/yum, Docker
+- [Configuration](configuration.md) — full YAML reference
+- [Access log](access-log.md) — NCSA format, JSON preset, LTSV preset
+- [CLI](cli.md) — command-line usage and flags
+
+## Features
+
+- Serve static files
+- Flexible routing (exact, prefix, and regular-expression match)
+- Access logging (NCSA, JSON, and LTSV presets; allocation-free hot path)
+- Reverse proxy
+- Customize request and response headers
+- TLS (HTTPS/SSL), including automatic certificates via Let's Encrypt (autocert / ACME)
+- Virtual hosts
+- YAML configuration with CLI override
+
+See the top-level [README](../README.md) for a quick feature tour, benchmarks and release-install snippets.

--- a/docs/access-log.md
+++ b/docs/access-log.md
@@ -1,0 +1,85 @@
+# Access log
+
+FastHttpd writes access logs through a `bufio.Writer` + `sync.Pool` pipeline that keeps the formatting hot path allocation-free for the classic NCSA format, the JSON preset and the LTSV preset.
+
+## NCSA format (default)
+
+`format` accepts an Apache-style format string. The default is the NCSA Common Log Format:
+
+```yaml
+accessLog:
+  output: logs/access.log
+  format: '%h %l %u %t "%r" %>s %b'
+```
+
+Format directives follow the [Apache Custom Log Formats](https://httpd.apache.org/docs/2.4/en/mod/mod_log_config.html) convention.
+
+## JSON preset
+
+Set `format: json` to emit one JSON object per request with the following 15 fields. The schema is flat `snake_case` so it can be ingested by jq, Loki, Elasticsearch, CloudWatch Logs Insights, and similar tools without transformation.
+
+```yaml
+accessLog:
+  output: logs/access.log
+  format: json
+  bufferSize: 4096
+  flushInterval: 1000
+```
+
+Sample output (one line, pretty-printed here for readability):
+
+```json
+{
+  "time": "2026-04-11T10:19:13+09:00",
+  "remote_addr": "10.1.2.3:51002",
+  "client_ip": "10.1.2.3",
+  "remote_user": "alice",
+  "method": "GET",
+  "uri": "/path?foo=bar",
+  "proto": "HTTP/1.1",
+  "scheme": "http",
+  "host": "example.com",
+  "status": 200,
+  "size": 1234,
+  "bytes_received": 0,
+  "duration_us": 412,
+  "referer": "https://example.com/",
+  "user_agent": "curl/8.7.1"
+}
+```
+
+Notes:
+
+- `time` is RFC 3339 with the local timezone offset.
+- `client_ip` is the left-most entry of the `X-Forwarded-For` header when present, otherwise the IP portion of the connecting peer.
+- `duration_us` is integer microseconds; the unit is encoded in the key name to avoid ambiguity.
+- `size` is the response body length and `bytes_received` is the request header + body byte count.
+
+## LTSV preset
+
+Set `format: ltsv` to emit one [Labeled Tab-separated Values](http://ltsv.org/) record per request. The 13-field schema follows the nginx / fluentd LTSV convention, so existing parsers and log forwarders ingest it without configuration.
+
+```yaml
+accessLog:
+  output: logs/access.log
+  format: ltsv
+  bufferSize: 4096
+  flushInterval: 1000
+```
+
+Sample output (one line, wrapped here for readability):
+
+```
+time:2026-04-11T10:19:13+09:00	host:10.1.2.3	forwardedfor:	user:alice
+	req:GET /path?foo=bar HTTP/1.1	scheme:http	vhost:example.com
+	status:200	size:1234	reqsize:0	reqtime_microsec:412
+	referer:https://example.com/	ua:curl/8.7.1
+```
+
+Notes:
+
+- `host` is the direct peer IP (without port), matching nginx's `$remote_addr`.
+- `forwardedfor` is the raw `X-Forwarded-For` header value; unlike the JSON preset, no left-most derivation is performed.
+- `req` combines the method, request URI and protocol NCSA-style.
+- Empty string fields are written as empty values, not `-`, following pure LTSV convention.
+- Any `TAB`, `LF` or `CR` byte inside a string value is replaced with a single space so a crafted header cannot break the LTSV line structure (equivalent to nginx's `escape=default`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,28 @@
+# CLI
+
+## Usage
+
+```
+FastHttpd is a HTTP server using valyala/fasthttp.
+
+Usage:
+  fasthttpd [flags] [query] ([file...])
+
+Flags:
+  -e value
+        edit expression (eg. -e KEY=VALUE)
+  -f string
+        configuration file
+  -h    help for fasthttpd
+  -v    print version
+```
+
+## Examples
+
+```sh
+fasthttpd -f examples/config.minimal.yaml
+fasthttpd -f examples/config.minimal.yaml -e accessLog.output=stdout
+fasthttpd -e root=./examples/public -e listen=0.0.0.0:8080
+```
+
+The `-e` flag overrides values in `config.yaml` using the expression syntax from [mojatter/tree](https://github.com/mojatter/tree).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,573 @@
+# Configuration
+
+## Built-in configuration
+
+The following is a minimal configuration built into fasthttpd.
+
+```yaml
+host: localhost
+listen: ':8080'
+root: ./public
+log:
+  output: stderr
+
+handlers:
+  'static':
+    type: fs
+    indexNames: [index.html]
+
+routes:
+  - path: /
+    handler: static
+```
+
+## Custom configuration
+
+The following configuration exercises most of the current FastHttpd features.
+
+<details>
+<summary>Expand full configuration</summary>
+
+```yaml
+host: localhost
+# NOTE: Define listen addr. IPv6 such as `[::1]:8080` is supported.
+listen: ':8080'
+root: ./public
+
+# Define fasthttp.Server settings.
+server:
+  name: fasthttpd
+  readBufferSize: 4096
+  writeBufferSize: 4096
+
+log:
+  output: logs/error.log
+  # NOTE: Flags supports date|time|microseconds
+  flags: [date, time]
+  rotation:
+    maxSize: 100
+
+accessLog:
+  output: logs/access.log
+  format: '%h %l %u %t "%r" %>s %b'
+  rotation:
+    maxSize: 100
+    maxBackups: 14
+    maxAge: 28
+    compress: true
+    localTime: true
+
+# Define custom error pages (x matches [0-9])
+errorPages:
+  '404': /err/404.html
+  '5xx': /err/5xx.html
+
+# Define named filters
+filters:
+
+  'auth':
+    type: basicAuth
+    users:
+      # WARNING: Defining plain secrets is unsafe. For development use only.
+      - name: fast
+        secret: httpd
+    usersFile: ./users.yaml
+
+  'cache':
+    type: header
+    response:
+      set:
+        'Cache-Control': 'private, max-age=3600'
+
+# Define named handlers
+handlers:
+
+  'static':
+    type: fs
+    indexNames: [index.html]
+    generateIndexPages: false
+    compress: true
+
+  'expvar':
+    type: expvar
+
+  'hello':
+    type: content
+    headers:
+      'Content-Type': 'text/plain; charset=utf-8'
+    body: |
+      Hello FastHttpd
+
+# Routes are processed in sequence and interrupted when `status` or `handler` is specified.
+routes:
+
+  # Allow GET, POST, HEAD only.
+  - methods: [PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH]
+    status: 405
+    statusMessage: 'Method not allowed'
+
+  # Route to /index.html.
+  - path: /
+    match: equal
+    handler: static
+
+  # Route to expvar handler.
+  - path: /expvar
+    match: equal
+    handler: expvar
+
+  # Redirect to external URL with status code 302.
+  - path: /redirect-external
+    match: equal
+    rewrite: http://example.com/
+    status: 302
+
+  # Redirect to internal URI with status code 302 and appendQueryString.
+  # If "GET /redirect-internal?name=value" is requested, it redirects to "/internal?foo=bar&name=value"
+  - path: /redirect-internal
+    match: equal
+    rewrite: /internal?foo=bar
+    rewriteAppendQueryString: true
+    status: 302
+
+  # Route to static resources using regexp.
+  - path: .*\.(js|css|jpg|png|gif|ico)$
+    match: regexp
+    filters: [cache]
+    methods: [GET, HEAD]
+    handler: static
+
+  # Rewrite the path and route to next (no handler and no status).
+  - path: ^/view/(.+)
+    match: regexp
+    rewrite: /view?id=$1
+
+  # Other requests are routed to hello with auth filter.
+  - filters: [auth]
+    handler: hello
+
+routesCache:
+  enable: true
+  expire: 60000
+
+---
+
+host: localhost
+listen: ':8443'
+
+ssl:
+  certFile: ./ssl/localhost.crt
+  keyFile: ./ssl/localhost.key
+
+handlers:
+  'backend':
+    type: proxy
+    url: 'http://localhost:8080'
+
+routes:
+  - path: /
+    handler: backend
+
+---
+
+include: conf.d/*.yaml
+```
+
+</details>
+
+## Host
+
+```yaml
+host: localhost
+```
+
+## Listen
+
+Listen represents the IP address and port.
+
+```yaml
+listen: ':8080'
+```
+
+## Root
+
+Path to the root directory to serve files from. `./` indicates the directory where `config.yaml` is located.
+
+```yaml
+root: ./public
+```
+
+## Server
+
+Server represents settings for `fasthttp.Server`.
+
+```yaml
+server:
+  name: fasthttpd
+  readBufferSize: 4096
+  writeBufferSize: 4096
+  readTimeout: 60s
+  writeTimeout: 60s
+```
+
+| Key | Description |
+| --- | ----------- |
+| `name` | Server name sent in response headers. |
+| `readBufferSize` | Per-connection buffer size for reading requests. This also limits the maximum header size. Increase this buffer if clients send multi-KB request URIs or headers (for example, BIG cookies). Uses fasthttp's default if not set. |
+| `writeBufferSize` | Per-connection buffer size for writing responses. Uses fasthttp's default if not set. |
+| `readTimeout` | Maximum time allowed to read the full request including the body. The read deadline is reset when the connection opens, or for keep-alive connections after the first byte has been read. Unlimited by default. Valid units: `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. |
+| `writeTimeout` | Maximum time before timing out a response write. Reset after the request handler returns. Unlimited by default. Same unit rules as `readTimeout`. |
+
+Other string, bool and numeric fields can also be set. See [fasthttp/server.go](https://github.com/valyala/fasthttp/blob/master/server.go) for details.
+
+## Log
+
+Log represents settings for logging.
+
+```yaml
+log:
+  output: logs/error.log
+  # NOTE: Flags supports date|time|microseconds
+  flags: [date, time]
+  rotation:
+    maxSize: 100
+    maxBackups: 14
+    maxAge: 28
+    compress: true
+    localTime: true
+```
+
+| Key | Description |
+| --- | ----------- |
+| `output` | Output file path. `stdout` and `stderr` are special strings that indicate standard output and standard error. |
+| `flags` | For example, `flags: [date, time]` produces `2009/01/23 01:23:23 message`. |
+| `rotation.maxSize` | Maximum size in megabytes before the log file is rotated. Defaults to 100 MB. |
+| `rotation.maxBackups` | Maximum number of rotated files to retain. The default is to keep all rotated files. |
+| `rotation.maxAge` | Maximum number of days to retain rotated files based on the timestamp in their filename. A "day" is defined as 24 hours. The default is not to remove files based on age. |
+| `rotation.compress` | Compress rotated log files with gzip. The default is no compression. |
+| `rotation.localTime` | Use the machine's local time for timestamps in backup filenames. The default is UTC. |
+
+The rotation is based on [natefinch/lumberjack](https://github.com/natefinch/lumberjack).
+
+## AccessLog
+
+AccessLog represents settings for request-level access logging.
+
+```yaml
+accessLog:
+  output: logs/access.log
+  format: '%h %l %u %t "%r" %>s %b'
+  rotation:
+    maxSize: 100
+    maxBackups: 14
+    maxAge: 28
+    compress: true
+    localTime: true
+```
+
+| Key | Description |
+| --- | ----------- |
+| `output` | Output file path. `stdout` and `stderr` are special strings for standard output and standard error. |
+| `format` | Apache-style format string, or `json` / `ltsv` to select a structured preset. See [Apache Custom Log Formats](https://httpd.apache.org/docs/2.4/en/mod/mod_log_config.html). |
+| `bufferSize` | Write-buffer size used by the background writer (bytes). |
+| `flushInterval` | Maximum time the buffer may sit unflushed (milliseconds). |
+| `rotation.*` | Same fields as `log.rotation`. |
+
+The JSON and LTSV presets emit a fixed schema per line; see [docs/access-log.md](access-log.md) for the full field list and samples.
+
+## ErrorPages
+
+```yaml
+# Define custom error pages (x matches [0-9])
+errorPages:
+  '404': /err/404.html
+  '5xx': /err/5xx.html
+```
+
+| Key | Description |
+| --- | ----------- |
+| `root` | (Optional) Override the top-level `root` for error-page lookup. |
+| `(http status)` | Path to the custom error page. The status key may contain `x` as a wildcard digit (e.g. `5xx`, `40x`). |
+
+## Filters
+
+Named filters can be declared under `filters`.
+
+```yaml
+filters:
+
+  'auth':
+    type: basicAuth
+    users:
+      # WARNING: Defining plain secrets is unsafe. For development use only.
+      - name: fast
+        secret: httpd
+    usersFile: ./users.yaml
+
+  'cache':
+    type: header
+    response:
+      set:
+        'Cache-Control': 'private, max-age=3600'
+```
+
+The following filter types are supported.
+
+- `basicAuth` — HTTP Basic access authentication.
+- `header` — customize request and response headers.
+
+### BasicAuth
+
+BasicAuth represents settings for HTTP Basic access authentication.
+
+```yaml
+filters:
+  'auth':
+    type: basicAuth
+    users:
+      # WARNING: Defining plain secrets is unsafe. For development use only.
+      - name: fast
+        secret: httpd
+    usersFile: ./users.yaml
+```
+
+| Key | Description |
+| --- | ----------- |
+| `users[].name` | User name. |
+| `users[].secret` | Plain secret. |
+| `usersFile` | Path to a users file. See [testdata/users.yaml](https://github.com/fasthttpd/fasthttpd/blob/main/pkg/config/testdata/users.yaml). |
+
+### Header
+
+Header represents settings for customizing request and response headers.
+
+```yaml
+filters:
+  'cache':
+    type: header
+    response:
+      set:
+        'Cache-Control': 'private, max-age=3600'
+```
+
+| Key | Description |
+| --- | ----------- |
+| `request.set` | Header-value mapping. Existing headers are overwritten. |
+| `request.add` | Header-value mapping. Appended to existing values. |
+| `request.del` | List of header names to delete. |
+| `response.set` | Header-value mapping. Existing headers are overwritten. |
+| `response.add` | Header-value mapping. Appended to existing values. |
+| `response.del` | List of header names to delete. |
+
+## Handlers
+
+Named handlers can be declared under `handlers`.
+
+```yaml
+handlers:
+
+  'static':
+    type: fs
+    indexNames: [index.html]
+    generateIndexPages: false
+    compress: true
+
+  'hello':
+    type: content
+    headers:
+      'Content-Type': 'text/plain; charset=utf-8'
+    body: |
+      Hello FastHttpd
+
+  'backend':
+    type: proxy
+    url: http://localhost:9000/
+```
+
+The following handler types are supported.
+
+- `fs` — serve static files from the local filesystem.
+- `content` — serve in-memory content.
+- `proxy` — reverse-proxy to a single backend.
+- `balancer` — reverse-proxy to multiple backends with a configurable algorithm.
+
+### FS
+
+FS serves static files from the local filesystem.
+
+```yaml
+handlers:
+  'static':
+    type: fs
+    indexNames: [index.html]
+    generateIndexPages: false
+    compress: true
+```
+
+| Key | Description |
+| --- | ----------- |
+| `root` | Path to the root directory. If omitted, the top-level `root` is used. |
+| `indexNames` | List of index file names to try when a directory is requested. |
+| `generateIndexPages` | Auto-generate index pages for directories that do not match `indexNames`. |
+| `compress` | Transparently compress responses. |
+
+Other string, bool and numeric fields can also be set. See [fasthttp/fs.go](https://github.com/valyala/fasthttp/blob/master/fs.go) for details.
+
+### Content
+
+Content serves in-memory content.
+
+```yaml
+handlers:
+  'hello':
+    type: content
+    headers:
+      'Content-Type': 'text/plain; charset=utf-8'
+    body: |
+      Hello FastHttpd
+```
+
+| Key | Description |
+| --- | ----------- |
+| `headers` | Key-value mapping or `Key: Value` list. |
+| `body` | Content body. |
+
+### Proxy
+
+Proxy reverse-proxies to a single backend.
+
+```yaml
+handlers:
+  'backend':
+    type: proxy
+    url: 'http://localhost:8080'
+```
+
+| Key | Description |
+| --- | ----------- |
+| `url` | Backend URL. |
+
+> **Note:** To proxy to multiple backends, use [Balancer](#balancer).
+
+### Balancer
+
+Balancer reverse-proxies to multiple backends, powered by [zehuamama/balancer](https://github.com/zehuamama/balancer).
+
+```yaml
+handlers:
+  'backend':
+    type: balancer
+    urls:
+      - http://localhost:9000/
+      - http://localhost:9001/
+      - http://localhost:9002/
+    algorithm: ip-hash
+    healthCheckInterval: 5
+```
+
+| Key | Description |
+| --- | ----------- |
+| `urls` | Backend URLs. |
+| `algorithm` | One of `ip-hash`, `consistent-hash`, `p2c`, `random`, `round-robin`, `least-load`, `bounded`. |
+| `healthCheckInterval` | Health-check interval in seconds. |
+
+> **Note:** If `Proxy` gains multi-backend support, `Balancer` may be deprecated.
+
+## Routes
+
+Routes are processed in sequence and interrupted when `status` or `handler` is specified.
+
+```yaml
+routes:
+  - path: / # The request path
+    match: prefix # The match type: prefix | equal | regexp
+    methods: [] # Allowed HTTP methods
+    filters: [] # Filter names
+    rewrite: '' # The rewrite path
+    rewriteAppendQueryString: false # Like Apache's QSA (Query String Append) flag
+    handler: '' # The handler name
+    status: 0 # HTTP status
+    statusMessage: '' # Custom HTTP status message
+```
+
+### Route examples
+
+Rewrite the path and route to a backend.
+
+```yaml
+handlers:
+  'backend':
+    type: proxy
+    url: 'http://localhost:8080'
+routes:
+  - path: ^/view/(.+)
+    match: regexp
+    rewrite: /view?id=$1
+  - path: /
+    handler: backend
+```
+
+Redirect to an external URL with status code 302.
+
+```yaml
+routes:
+  - path: /redirect-external
+    match: equal
+    rewrite: http://example.com/
+    status: 302
+```
+
+## Routes Cache
+
+Route calculations are cached, yielding significant gains when routing relies heavily on regular expressions.
+
+```yaml
+routesCache:
+  enable: true
+  expire: 60000    # TTL in milliseconds
+  interval: 60000  # Background eviction interval in milliseconds
+  maxEntries: 0    # 0 (default) means unbounded; set a positive value to cap the cache
+```
+
+| Key | Description |
+| --- | ----------- |
+| `enable` | Enable the routes cache. |
+| `expire` | Entry TTL in milliseconds. Defaults to 5 minutes (300000) when omitted or non-positive. |
+| `interval` | Minimum gap between background eviction passes, in milliseconds. Defaults to 1 minute (60000) when omitted or non-positive. |
+| `maxEntries` | Maximum number of stored entries. When the cap is reached, `Set` on a new key is dropped (existing entries are preserved); this prioritizes already-cached hot paths over adversarial unique-key floods. Zero or negative means unbounded. |
+
+## SSL
+
+```yaml
+ssl:
+  certFile: ./ssl/localhost.crt
+  keyFile: ./ssl/localhost.key
+```
+
+## SSL auto cert
+
+```yaml
+ssl:
+  autoCert: true
+  autoCertCacheDir: /etc/fasthttpd/cache
+```
+
+See [examples/config.autocert.yaml](https://github.com/fasthttpd/fasthttpd/blob/main/examples/config.autocert.yaml) for a runnable example.
+
+## Virtual hosts
+
+Virtual hosts can be defined in a multi-document YAML file. The first document is the default host.
+
+```yaml
+host: default.example.com
+listen: ':80'
+---
+host: other.example.com
+listen: ':80'
+```
+
+## Include
+
+```yaml
+include: /etc/fasthttpd/conf.d/*.yaml
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,40 @@
+# Getting started
+
+This guide walks through serving static files with FastHttpd.
+
+## Configuration
+
+The following is a minimal configuration built into fasthttpd.
+
+```yaml
+host: localhost
+listen: ':8080'
+root: ./public
+log:
+  output: stderr
+
+handlers:
+  'static':
+    type: fs
+    indexNames: [index.html]
+
+routes:
+  - path: /
+    handler: static
+```
+
+## Start fasthttpd
+
+Start fasthttpd with a partial override of the built-in configuration, then open <http://localhost:8080/> in your browser.
+
+```sh
+fasthttpd -e root=.
+```
+
+Or specify your configuration file:
+
+```sh
+fasthttpd -f config.yaml
+```
+
+See [Configuration](configuration.md) for the full reference, and [CLI](cli.md) for command-line flags.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,64 @@
+# Installation
+
+## Go install
+
+```sh
+go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
+```
+
+## Download binary
+
+Download a binary from the [releases page](https://github.com/fasthttpd/fasthttpd/releases).
+
+```sh
+VERSION=0.7.0 GOOS=linux GOARCH=amd64; \
+  curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
+  tar xz fasthttpd && \
+  sudo mv fasthttpd /usr/sbin
+```
+
+- `GOOS` supports `linux`, `darwin`, `windows`
+- `GOARCH` supports `amd64`, `arm64`, `386`
+
+## Homebrew
+
+```sh
+brew tap fasthttpd/fasthttpd
+brew install fasthttpd
+```
+
+## Using yum or apt
+
+Download a `.deb` or `.rpm` package from the [releases page](https://github.com/fasthttpd/fasthttpd/releases), then run `apt install` or `yum install`.
+
+```sh
+VERSION=0.7.0 ARCH=amd64; \
+  curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
+sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
+```
+
+- Default configuration path is `/etc/fasthttpd/config.yaml`
+- Default log directory is `/var/log/fasthttpd`
+- FastHttpd is started automatically by systemd
+
+## Docker
+
+See <https://hub.docker.com/r/fasthttpd/fasthttpd>.
+
+### Exposing an external port
+
+```sh
+docker run --rm -p 8080:80 fasthttpd/fasthttpd
+```
+
+### Serve static content
+
+```sh
+docker run --rm -p 8080:80 -v $(pwd)/public:/usr/share/fasthttpd/html fasthttpd/fasthttpd
+```
+
+### Specify a config file
+
+```sh
+docker run --rm -p 8080:80 -v your.config.yaml:/etc/fasthttpd/config.yaml fasthttpd/fasthttpd
+```


### PR DESCRIPTION
## Summary
- Import the five fasthttpd-hugo pages into `docs/` as plain markdown. Hugo shortcodes (`{{< columns >}}`, `{{< details >}}`, `{{< hint >}}`, `{{< param version >}}`) rewritten in CommonMark.
- Move the ~150-line "full configuration" YAML and the JSON/LTSV access-log schemas out of README.md into `docs/configuration.md` / new `docs/access-log.md`. README now keeps quick-start, install, override examples, RoutesCache benchmark, and AccessLog benchmark.
- `docs/configuration.md` adds `routesCache.interval` and `routesCache.maxEntries` (shipped in 0.8.0 prep).
- README: replace the `fasthttpd.org/configuration` link with `docs/configuration.md`; drop the `## TODO` section (HTTP/3 was aspirational and not in active plan; benchmark reports are already present in README).

## Test plan
- [x] `go test ./...`
- [x] `grep -r fasthttpd.org .` returns no matches
- [x] Visual spot-check on GitHub after merge: `docs/README.md`, `docs/configuration.md` (tables and `<details>`), `docs/access-log.md`, `README.md` (length sanity)

## Follow-up (out of scope)
- Archive the old `fasthttpd/fasthttpd-hugo` repo with a migration notice.
- Bump `VERSION=0.7.0` → `0.8.0` in README and `docs/installation.md` in the version-bump PR.
- Tag `v0.8.0` covering the 0-alloc work plus this docs migration.