### PR TITLE
chore: Bump version to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 FastHttpd is a lightweight http server using [valyala/fasthttp](https://github.com/valyala/fasthttp).
 
-> FastHttpd and fasthttp are versioned independently. FastHttpd **v0.7.0** is built against fasthttp **v1.70.0**.
+> FastHttpd and fasthttp are versioned independently. FastHttpd **v0.8.0** is built against fasthttp **v1.70.0**.
 
 ## Features
 
@@ -32,7 +32,7 @@ go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
 Download binary from [release](https://github.com/fasthttpd/fasthttpd/releases).
 
 ```sh
-VERSION=0.7.0 GOOS=linux GOARCH=amd64; \
+VERSION=0.8.0 GOOS=linux GOARCH=amd64; \
   curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
   tar xz fasthttpd && \
   sudo mv fasthttpd /usr/sbin
@@ -53,7 +53,7 @@ brew install fasthttpd
 Download deb or rpm from [release](https://github.com/fasthttpd/fasthttpd/releases), and then execute `apt install` or `yum install`. 
 
 ```sh
-VERSION=0.7.0 ARCH=amd64; \
+VERSION=0.8.0 ARCH=amd64; \
   curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
 sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
 Download a binary from the [releases page](https://github.com/fasthttpd/fasthttpd/releases).
 
 ```sh
-VERSION=0.7.0 GOOS=linux GOARCH=amd64; \
+VERSION=0.8.0 GOOS=linux GOARCH=amd64; \
   curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
   tar xz fasthttpd && \
   sudo mv fasthttpd /usr/sbin
@@ -32,7 +32,7 @@ brew install fasthttpd
 Download a `.deb` or `.rpm` package from the [releases page](https://github.com/fasthttpd/fasthttpd/releases), then run `apt install` or `yum install`.
 
 ```sh
-VERSION=0.7.0 ARCH=amd64; \
+VERSION=0.8.0 ARCH=amd64; \
   curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
 sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
 ```


### PR DESCRIPTION
## Summary
- Update `VERSION=0.7.0` → `0.8.0` in README.md (2 spots) and docs/installation.md (2 spots).
- Update the fasthttp compatibility line in README.md (v0.7.0 → v0.8.0). fasthttp itself stays at v1.70.0.

## Release highlights (v0.7.0 → v0.8.0)
- #46 Allocation benchmarks for filter and Content handler (test infra).
- #48 Zero-alloc `Content.Handle` via precompiled config (user-visible perf).
- #49 Expire cache: allocation/goroutine churn reduction, `MaxEntries` cap, constructor API consolidated into `NewCache(CacheConfig)`. **Breaking for direct `pkg/util` consumers** — `NewExpireCache`, `NewExpireCacheInterval`, `NewExpireCacheIntervalMax` are replaced by `NewCache(CacheConfig{...})`.
- #50 Docs integration: `fasthttpd-hugo` pages imported as plain markdown under `docs/`.
- #51 Remove stale `tools/bump.sh`.

## Test plan
- [x] `go test ./...`
- [x] `grep -r '0\.7\.0' .` returns no matches (version strings fully updated)
- [x] After merge: push `v0.8.0` tag to trigger the release workflow.