### PR TITLE
refactor(cmd): Simplify HUP handling and handle SIGTERM

### DIFF
--- a/pkg/cmd/fasthttpd.go
+++ b/pkg/cmd/fasthttpd.go
@@ -252,6 +252,7 @@ func (d *FastHttpd) handleHUP() {
 
 	go func() {
 		for range ch {
+			log.Println("received SIGHUP, rotating logs")
 			if err := logger.RotateShared(); err != nil {
 				log.Printf("failed to rotate logs: %v", err)
 			}

--- a/pkg/cmd/fasthttpd.go
+++ b/pkg/cmd/fasthttpd.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/fasthttpd/fasthttpd/pkg/config"
@@ -64,7 +65,10 @@ type FastHttpd struct {
 	configFile string
 	editExprs  util.StringList
 	servers    []*fasthttp.Server
-	stopHup    context.CancelFunc
+
+	hupMu    sync.Mutex
+	hupCh    chan os.Signal
+	hupClose sync.Once
 }
 
 func NewFastHttpd() *FastHttpd {
@@ -188,11 +192,11 @@ func (d *FastHttpd) run() error {
 		listenedCfgs[cfg.Listen] = append(listenedCfgs[cfg.Listen], cfg)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
 	go func() {
 		<-ctx.Done()
-		// log.Printf("signal int: shutdown fasthttpd")
 		if err := d.Shutdown(); err != nil {
 			log.Printf("failed to shutdown: %v", err)
 		}
@@ -200,7 +204,7 @@ func (d *FastHttpd) run() error {
 
 	d.handleHUP()
 
-	errChs := make(chan error, 2)
+	errChs := make(chan error, len(listenedCfgs))
 	for listen, cfgs := range listenedCfgs {
 		h, err := handler.NewServerHandler(cfgs)
 		if err != nil {
@@ -239,30 +243,40 @@ func (d *FastHttpd) run() error {
 }
 
 func (d *FastHttpd) handleHUP() {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGHUP)
-	d.stopHup = stop
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGHUP)
+
+	d.hupMu.Lock()
+	d.hupCh = ch
+	d.hupMu.Unlock()
+
 	go func() {
-		for {
-			<-ctx.Done()
-			if d.stopHup == nil {
-				break
-			}
-			// log.Printf("signal hup: rotate logs")
+		for range ch {
 			if err := logger.RotateShared(); err != nil {
-				log.Printf("failed to rotate stored: %v", err)
+				log.Printf("failed to rotate logs: %v", err)
 			}
-			stop()
-			ctx, stop = signal.NotifyContext(context.Background(), syscall.SIGHUP)
-			d.stopHup = stop
 		}
 	}()
 }
 
-func (d *FastHttpd) Shutdown() error {
-	if stopHup := d.stopHup; stopHup != nil {
-		d.stopHup = nil
-		stopHup()
+func (d *FastHttpd) stopHUP() {
+	d.hupMu.Lock()
+	ch := d.hupCh
+	d.hupMu.Unlock()
+
+	if ch == nil {
+		return
 	}
+
+	d.hupClose.Do(func() {
+		signal.Stop(ch)
+		close(ch)
+	})
+}
+
+func (d *FastHttpd) Shutdown() error {
+	d.stopHUP()
+
 	var errs []error
 	for _, server := range d.servers {
 		if err := server.Shutdown(); err != nil {

--- a/pkg/cmd/fasthttpd_test.go
+++ b/pkg/cmd/fasthttpd_test.go
@@ -5,8 +5,13 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/fasthttpd/fasthttpd/pkg/config"
+	"github.com/fasthttpd/fasthttpd/pkg/logger"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttputil"
 )
@@ -59,4 +64,47 @@ func TestFastHttpd(t *testing.T) {
 	if resp.Header.ContentLength() != int(info.Size()) {
 		t.Errorf("unexpected content length %d; want %d", resp.Header.ContentLength(), info.Size())
 	}
+}
+
+func TestFastHttpd_HandleHUP(t *testing.T) {
+	// Note: no t.Parallel — this test sends SIGHUP to the whole test process.
+
+	tmpDir := t.TempDir()
+	output := filepath.Join(tmpDir, "hup.log")
+
+	rotator, err := logger.SharedRotator(output, config.Rotation{
+		MaxSize:    1,
+		MaxBackups: 2,
+		MaxAge:     3,
+		LocalTime:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rotator.Close()
+
+	if _, err := rotator.Write([]byte("before rotate\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewFastHttpd()
+	d.handleHUP()
+	defer d.Shutdown() //nolint:errcheck
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGHUP); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) >= 2 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("rotation did not happen within deadline")
 }


### PR DESCRIPTION
## Summary

- Replace the one-shot `signal.NotifyContext` re-registration loop for SIGHUP with a plain `signal.Notify` + `for range ch` pattern. HUP is a repeating signal, so using the repeating API directly removes the stop/re-register dance entirely.
- Catch SIGTERM alongside SIGINT so `docker stop` and systemd's default stop signal now trigger graceful shutdown instead of SIGKILL.
- Size the `errChs` buffer to `len(listenedCfgs)` instead of a fixed 2.
- Guard the HUP channel lifetime with `sync.Mutex` + `sync.Once` in place of the previous lock-free read/write of `d.stopHup`.

## Test plan

- [x] `go test -race ./...`
- [x] Send `SIGHUP` repeatedly to a running fasthttpd and confirm logs rotate on each signal
- [x] Send `SIGTERM` (e.g. `docker stop`) and confirm graceful shutdown runs
- [x] Normal `SIGINT` (Ctrl+C) still terminates the process