### PR TITLE
feat(cmd): Add bounded Shutdown with per-server shutdownTimeout

### DIFF
--- a/pkg/cmd/fasthttpd.go
+++ b/pkg/cmd/fasthttpd.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/fasthttpd/fasthttpd/pkg/config"
 	"github.com/fasthttpd/fasthttpd/pkg/handler"
@@ -59,12 +60,13 @@ func newMinimalConfig() config.Config {
 }
 
 type FastHttpd struct {
-	flagSet    *flag.FlagSet
-	isVersion  bool
-	isHelp     bool
-	configFile string
-	editExprs  util.StringList
-	servers    []*fasthttp.Server
+	flagSet          *flag.FlagSet
+	isVersion        bool
+	isHelp           bool
+	configFile       string
+	editExprs        util.StringList
+	servers          []*fasthttp.Server
+	shutdownTimeouts []time.Duration
 
 	hupMu    sync.Mutex
 	hupCh    chan os.Signal
@@ -223,6 +225,7 @@ func (d *FastHttpd) run() error {
 
 		h.Logger().Printf("starting fasthttpd on %q", listen)
 		d.servers = append(d.servers, server)
+		d.shutdownTimeouts = append(d.shutdownTimeouts, cfgs[0].ShutdownTimeoutDuration())
 
 		go func() {
 			err := server.Serve(ln)
@@ -278,15 +281,22 @@ func (d *FastHttpd) stopHUP() {
 func (d *FastHttpd) Shutdown() error {
 	d.stopHUP()
 
-	var errs []error
-	for _, server := range d.servers {
-		if err := server.Shutdown(); err != nil {
-			errs = append(errs, err)
-		}
+	var wg sync.WaitGroup
+	errs := make([]error, len(d.servers))
+	for i, server := range d.servers {
+		wg.Go(func() {
+			ctx := context.Background()
+			if timeout := d.shutdownTimeouts[i]; timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, timeout)
+				defer cancel()
+			}
+			if err := server.ShutdownWithContext(ctx); err != nil {
+				errs[i] = err
+			}
+		})
 	}
-	if len(errs) == 0 {
-		return nil
-	}
+	wg.Wait()
 	return errors.Join(errs...)
 }
 

--- a/pkg/cmd/fasthttpd_test.go
+++ b/pkg/cmd/fasthttpd_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bufio"
+	"context"
+	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -107,4 +109,88 @@ func TestFastHttpd_HandleHUP(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatal("rotation did not happen within deadline")
+}
+
+func TestFastHttpd_Shutdown(t *testing.T) {
+	testCases := []struct {
+		caseName       string
+		timeout        time.Duration
+		blockHandler   bool
+		wantErrIs      error
+		wantMaxElapsed time.Duration
+	}{
+		{
+			caseName:       "no_open_connections_returns_fast",
+			timeout:        0,
+			blockHandler:   false,
+			wantErrIs:      nil,
+			wantMaxElapsed: 500 * time.Millisecond,
+		},
+		{
+			caseName:       "timeout_elapses_with_blocked_handler",
+			timeout:        100 * time.Millisecond,
+			blockHandler:   true,
+			wantErrIs:      context.DeadlineExceeded,
+			wantMaxElapsed: 500 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			t.Parallel()
+
+			ln := fasthttputil.NewInmemoryListener()
+			defer ln.Close()
+
+			blockCh := make(chan struct{})
+			defer close(blockCh)
+
+			server := &fasthttp.Server{
+				Handler: func(ctx *fasthttp.RequestCtx) {
+					if tc.blockHandler {
+						<-blockCh
+					}
+				},
+			}
+
+			serveDone := make(chan struct{})
+			go func() {
+				_ = server.Serve(ln)
+				close(serveDone)
+			}()
+
+			if tc.blockHandler {
+				c, err := ln.Dial()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer c.Close()
+
+				if _, err := c.Write([]byte("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")); err != nil {
+					t.Fatal(err)
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+
+			d := &FastHttpd{
+				servers:          []*fasthttp.Server{server},
+				shutdownTimeouts: []time.Duration{tc.timeout},
+			}
+
+			start := time.Now()
+			err := d.Shutdown()
+			elapsed := time.Since(start)
+
+			if tc.wantErrIs == nil {
+				if err != nil {
+					t.Errorf("Shutdown() returned %v; want nil", err)
+				}
+			} else if !errors.Is(err, tc.wantErrIs) {
+				t.Errorf("Shutdown() returned %v; want errors.Is(%v)", err, tc.wantErrIs)
+			}
+			if elapsed > tc.wantMaxElapsed {
+				t.Errorf("Shutdown() took %v; want <= %v", elapsed, tc.wantMaxElapsed)
+			}
+		})
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,8 +14,9 @@ import (
 
 // Default values.
 const (
-	DefaultListen     = ":8080"
-	DefaultServerName = "fasthttpd"
+	DefaultListen          = ":8080"
+	DefaultServerName      = "fasthttpd"
+	DefaultShutdownTimeout = "30s"
 )
 
 // Supported Route.Match values.
@@ -28,25 +29,27 @@ const (
 // Config represents a configuration root of fasthttpd.
 // If Include is not empty, other keys are ignored.
 type Config struct {
-	Host        string              `yaml:"host"`
-	Listen      string              `yaml:"listen"`
-	SSL         SSL                 `yaml:"ssl"`
-	Root        string              `yaml:"root"`
-	Server      tree.Map            `yaml:"server"`
-	Log         Log                 `yaml:"log"`
-	AccessLog   AccessLog           `yaml:"accessLog"`
-	ErrorPages  map[string]string   `yaml:"errorPages"`
-	Filters     map[string]tree.Map `yaml:"filters"`
-	Handlers    map[string]tree.Map `yaml:"handlers"`
-	Routes      []Route             `yaml:"routes"`
-	RoutesCache RoutesCache         `yaml:"routesCache"`
-	Include     string              `yaml:"include"`
+	Host            string              `yaml:"host"`
+	Listen          string              `yaml:"listen"`
+	SSL             SSL                 `yaml:"ssl"`
+	Root            string              `yaml:"root"`
+	Server          tree.Map            `yaml:"server"`
+	Log             Log                 `yaml:"log"`
+	AccessLog       AccessLog           `yaml:"accessLog"`
+	ErrorPages      map[string]string   `yaml:"errorPages"`
+	Filters         map[string]tree.Map `yaml:"filters"`
+	Handlers        map[string]tree.Map `yaml:"handlers"`
+	Routes          []Route             `yaml:"routes"`
+	RoutesCache     RoutesCache         `yaml:"routesCache"`
+	ShutdownTimeout string              `yaml:"shutdownTimeout"`
+	Include         string              `yaml:"include"`
 }
 
 // SetDefaults sets default values.
 func (cfg Config) SetDefaults() Config {
 	cfg.Listen = DefaultListen
 	cfg.Server = tree.Map{"name": tree.ToValue(DefaultServerName)}
+	cfg.ShutdownTimeout = DefaultShutdownTimeout
 	cfg.SSL = cfg.SSL.SetDefaults()
 	cfg.Log = cfg.Log.SetDefaults()
 	cfg.AccessLog = cfg.AccessLog.SetDefaults()
@@ -82,6 +85,11 @@ func (cfg Config) Normalize() (Config, error) {
 	if cfg.SSL, err = cfg.SSL.Normalize(); err != nil {
 		return cfg, err
 	}
+	if cfg.ShutdownTimeout != "" {
+		if _, err := time.ParseDuration(cfg.ShutdownTimeout); err != nil {
+			return cfg, fmt.Errorf("failed to parse shutdownTimeout: %w", err)
+		}
+	}
 	for _, route := range cfg.Routes {
 		if route.Handler != "" {
 			if _, ok := cfg.Handlers[route.Handler]; !ok {
@@ -90,6 +98,17 @@ func (cfg Config) Normalize() (Config, error) {
 		}
 	}
 	return cfg, nil
+}
+
+// ShutdownTimeoutDuration returns the parsed ShutdownTimeout. A non-positive
+// value means no deadline (use context.Background()). Assumes Normalize has
+// already validated the string.
+func (cfg Config) ShutdownTimeoutDuration() time.Duration {
+	if cfg.ShutdownTimeout == "" {
+		return 0
+	}
+	d, _ := time.ParseDuration(cfg.ShutdownTimeout)
+	return d
 }
 
 // SSL represents a configuration of SSL. If AutoCert is true, CertFile and

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,11 +156,11 @@ func (l Log) SetDefaults() Log {
 
 // AccessLog represents a configuration of access log.
 type AccessLog struct {
-	Output        string   `yaml:"output"`
-	Format        string   `yaml:"format"`
-	QueueSize     int      `yaml:"queueSize"`     // Deprecated: silently ignored. Use BufferSize instead.
-	BufferSize    int      `yaml:"bufferSize"`
-	FlushInterval int      `yaml:"flushInterval"` // milliseconds
+	Output        string `yaml:"output"`
+	Format        string `yaml:"format"`
+	QueueSize     int    `yaml:"queueSize"` // Deprecated: silently ignored. Use BufferSize instead.
+	BufferSize    int    `yaml:"bufferSize"`
+	FlushInterval int    `yaml:"flushInterval"` // milliseconds
 	Rotation      Rotation
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -144,6 +144,7 @@ func TestUnmarshalYAMLPath(t *testing.T) {
 				Enable: true,
 				Expire: 60000,
 			},
+			ShutdownTimeout: DefaultShutdownTimeout,
 		}, {
 			Host:      "localhost",
 			Listen:    ":8443",
@@ -168,6 +169,7 @@ func TestUnmarshalYAMLPath(t *testing.T) {
 					Handler: "backend",
 				},
 			},
+			ShutdownTimeout: DefaultShutdownTimeout,
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -226,19 +228,21 @@ func TestUnmarshalYAMLPath_Include(t *testing.T) {
 	}
 	want := []Config{
 		{
-			Host:      "include1.local",
-			Listen:    ":8080",
-			Server:    tree.Map{"name": tree.ToValue("fasthttpd")},
-			SSL:       SSL{}.SetDefaults(),
-			Log:       Log{}.SetDefaults(),
-			AccessLog: AccessLog{}.SetDefaults(),
+			Host:            "include1.local",
+			Listen:          ":8080",
+			Server:          tree.Map{"name": tree.ToValue("fasthttpd")},
+			SSL:             SSL{}.SetDefaults(),
+			Log:             Log{}.SetDefaults(),
+			AccessLog:       AccessLog{}.SetDefaults(),
+			ShutdownTimeout: DefaultShutdownTimeout,
 		}, {
-			Host:      "include2.local",
-			Listen:    ":8080",
-			Server:    tree.Map{"name": tree.ToValue("fasthttpd")},
-			SSL:       SSL{}.SetDefaults(),
-			Log:       Log{}.SetDefaults(),
-			AccessLog: AccessLog{}.SetDefaults(),
+			Host:            "include2.local",
+			Listen:          ":8080",
+			Server:          tree.Map{"name": tree.ToValue("fasthttpd")},
+			SSL:             SSL{}.SetDefaults(),
+			Log:             Log{}.SetDefaults(),
+			AccessLog:       AccessLog{}.SetDefaults(),
+			ShutdownTimeout: DefaultShutdownTimeout,
 		},
 	}
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
## Summary

- Introduce top-level \`shutdownTimeout\` config option (default \`30s\`). Set to \`0\` to opt out of the deadline.
- Switch \`FastHttpd.Shutdown()\` from the unbounded \`server.Shutdown()\` to \`ShutdownWithContext\` with a per-server \`context.WithTimeout\`, run in parallel across all listening servers. Without a deadline, keepalive connections could hang shutdown indefinitely.
- Apply gofmt to the \`AccessLog\` struct tags (latent non-canonical alignment, unrelated to the rest but surfaced during this work).

## Test plan

- [x] \`go test -race ./...\`
- [x] Shutdown with no open connections returns promptly
- [x] Shutdown with a blocked handler returns \`context.DeadlineExceeded\` after the configured timeout