### PR TITLE
refactor: Replace //nolint:errcheck with _ = for ignored returns

### DIFF
--- a/pkg/handler/server.go
+++ b/pkg/handler/server.go
@@ -166,7 +166,7 @@ func (h *hostHandler) init() error {
 	h.handlers = map[string]fasthttp.RequestHandler{}
 	for name, hcfg := range h.cfg.Handlers {
 		if hcfg.Get("root").Value().String() == "" {
-			hcfg.Set("root", tree.ToValue(h.cfg.Root)) //nolint:errcheck
+			_ = hcfg.Set("root", tree.ToValue(h.cfg.Root))
 		}
 		hh, err := NewHandler(hcfg, l)
 		if err != nil {

--- a/pkg/logger/accesslog/accesslog.go
+++ b/pkg/logger/accesslog/accesslog.go
@@ -125,7 +125,7 @@ func (l *accessLog) Close() error {
 	close(l.done)
 
 	l.mu.Lock()
-	l.bw.Flush() //nolint:errcheck // best-effort flush on close
+	_ = l.bw.Flush() // best-effort flush on close
 	l.mu.Unlock()
 
 	l.appendLine = nil
@@ -156,7 +156,7 @@ func (l *accessLog) flushLoop(interval time.Duration) {
 			return
 		case <-ticker.C:
 			l.mu.Lock()
-			l.bw.Flush() //nolint:errcheck // periodic best-effort flush
+			_ = l.bw.Flush() // periodic best-effort flush
 			l.mu.Unlock()
 		}
 	}

--- a/pkg/logger/accesslog/accesslog_bench_test.go
+++ b/pkg/logger/accesslog/accesslog_bench_test.go
@@ -51,7 +51,7 @@ func openBenchTempFile(b *testing.B) *os.File {
 		b.Fatalf("CreateTemp: %v", err)
 	}
 	b.Cleanup(func() {
-		f.Close() //nolint:errcheck // bench cleanup
+		_ = f.Close() // bench cleanup
 	})
 	return f
 }
@@ -66,7 +66,7 @@ func openBenchDevNull(b *testing.B) *os.File {
 		b.Fatalf("open %s: %v", os.DevNull, err)
 	}
 	b.Cleanup(func() {
-		f.Close() //nolint:errcheck // bench cleanup
+		_ = f.Close() // bench cleanup
 	})
 	return f
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -28,7 +28,7 @@ func NewLogger(cfg config.Log) (Logger, error) {
 	}
 	l, err := newLogger(out, cfg)
 	if err != nil {
-		out.Close() //nolint:errcheck
+		_ = out.Close()
 		return nil, err
 	}
 	return l, nil

--- a/pkg/net/tcp.go
+++ b/pkg/net/tcp.go
@@ -34,12 +34,12 @@ func (ln *TcpKeepaliveListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 	if err := tc.SetKeepAlive(ln.Keepalive); err != nil {
-		tc.Close() //nolint:errcheck
+		_ = tc.Close()
 		return nil, err
 	}
 	if ln.KeepalivePeriod > 0 {
 		if err := tc.SetKeepAlivePeriod(ln.KeepalivePeriod); err != nil {
-			tc.Close() //nolint:errcheck
+			_ = tc.Close()
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Summary

Replace \`x() //nolint:errcheck\` with \`_ = x()\` for intentionally-ignored return values at non-\`defer\` call sites. The underscore assignment is idiomatic Go (the stdlib and upstream fasthttp use this style), expresses intent locally without a linter directive, and doesn't depend on a particular linter being in use.

Reason-bearing comments (\`// best-effort flush on close\`, \`// periodic best-effort flush\`, \`// bench cleanup\`) are preserved; only the \`//nolint:errcheck\` token is removed.

\`defer x() //nolint:errcheck\` usages are left alone — rewriting to \`defer func() { _ = x() }()\` is more noise than the nolint comment they replace.

## Test plan

- [x] \`go vet ./...\`
- [x] \`go test -race ./...\`