### PR TITLE
refactor: Replace interface{} with any

### DIFF
--- a/pkg/handler/server.go
+++ b/pkg/handler/server.go
@@ -61,7 +61,7 @@ func newVirtualHandler(cfgs []config.Config) (*virtualHandler, error) {
 	return &virtualHandler{
 		handlers: handlers,
 		logger: &logger.LoggerDelegator{
-			PrintfFunc: func(format string, args ...interface{}) {
+			PrintfFunc: func(format string, args ...any) {
 				for _, l := range loggers {
 					l.Printf(format, args...)
 				}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -109,7 +109,7 @@ var (
 	_            Logger = (*nilLogger)(nil)
 )
 
-func (nilLogger) Printf(format string, args ...interface{}) {}
+func (nilLogger) Printf(format string, args ...any) {}
 func (nilLogger) Rotate() error                             { return nil }
 func (nilLogger) Write([]byte) (int, error)                 { return 0, nil }
 func (nilLogger) Close() error                              { return nil }
@@ -117,14 +117,14 @@ func (nilLogger) LogLogger() *log.Logger                    { return NilLogLogge
 
 // LoggerDelegator can delegate the Logger functions.
 type LoggerDelegator struct {
-	PrintfFunc    func(format string, args ...interface{})
+	PrintfFunc    func(format string, args ...any)
 	RotateFunc    func() error
 	WriteFunc     func([]byte) (int, error)
 	CloseFunc     func() error
 	LogLoggerFunc func() *log.Logger
 }
 
-func (l *LoggerDelegator) Printf(format string, args ...interface{}) {
+func (l *LoggerDelegator) Printf(format string, args ...any) {
 	if l.PrintfFunc != nil {
 		l.PrintfFunc(format, args...)
 	}

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -112,7 +112,7 @@ func (r *Route) rewrite(path []byte) []byte {
 	return r.rewriteUriBytes
 }
 
-func onResultReleased(_ util.CacheKey, value interface{}) {
+func onResultReleased(_ util.CacheKey, value any) {
 	if r, ok := value.(*Result); ok {
 		r.Release()
 	}


### PR DESCRIPTION
## Summary

Mechanical replacement of \`interface{}\` with the \`any\` alias (Go 1.18+). Matches modern Go style; gopls flagged these locations.

Touches:

- \`pkg/logger/logger.go\` — \`Printf\` / \`PrintfFunc\` signatures
- \`pkg/handler/server.go\` — \`virtualHandler.PrintfFunc\` literal
- \`pkg/route/route.go\` — \`onResultReleased\` callback signature

## Test plan

- [x] \`go vet ./...\`
- [x] \`go test -race ./...\`