### PR TITLE
feat(cmd): Add -t / -T flags to test and dump the final configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,20 @@ Then you can hit http://localhost:8080 in your browser.
 Usage
 
 ```sh
-FastHttpd is a HTTP server using valyala/fasthttp.
+FastHttpd is a lightweight http server using valyala/fasthttp.
 
 Usage:
-  fasthttpd [flags] [query] ([file...])
+  fasthttpd [flags]
 
 Flags:
+  -T value
+    	test configuration and dump it (yaml|json; default yaml)
   -e value
     	edit expression (eg. -e KEY=VALUE)
   -f string
     	configuration file
   -h	help for fasthttpd
+  -t	test configuration and exit
   -v	print version
 ```
 
@@ -97,6 +100,8 @@ Examples
 % fasthttpd -f examples/config.minimal.yaml
 % fasthttpd -f examples/config.minimal.yaml -e accessLog.output=stdout
 % fasthttpd -e root=./examples/public -e listen=0.0.0.0:8080
+% fasthttpd -t -f examples/config.minimal.yaml
+% fasthttpd -T -f examples/config.minimal.yaml -e listen=:9000
 ```
 
 ## Configuration
@@ -140,6 +145,35 @@ Show access log and disable other log
 ```sh
 fasthttpd -f config.yaml -e log.output="" -e accessLog.output=stdout
 ```
+
+## Test and dump the final configuration
+
+FastHttpd can validate the config without starting the server. `-t`
+runs Load / Edit / Validate / FromTreeMaps and reports success or the
+first error.
+
+```sh
+fasthttpd -t -f config.yaml
+```
+
+`-T` additionally dumps the final, normalized configuration to stdout
+(`-T=yaml` by default, `-T=json` for JSON). When combined with `-e`,
+the pre-Edit configuration is written to **stderr** so stdout stays a
+single parseable document:
+
+```sh
+# See the config as written vs. as served
+fasthttpd -T -f config.yaml -e listen=:9000
+
+# Pipe the normalized config through jq
+fasthttpd -T=json -f config.yaml | jq '.[0].Routes'
+
+# Save the pre-Edit snapshot aside
+fasthttpd -T -f config.yaml -e root=/custom 2> pre.yaml
+```
+
+On a TTY the pre-Edit block is dimmed so the primary (stdout) output
+stands out. Set `NO_COLOR` to disable.
 
 ## RoutesCache
 

--- a/pkg/cmd/dump.go
+++ b/pkg/cmd/dump.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/fasthttpd/fasthttpd/pkg/config"
+	"github.com/mojatter/tree"
+	"go.yaml.in/yaml/v3"
+)
+
+// dumpFormat backs the -T flag. Implementing IsBoolFlag lets users
+// write bare "-T" (treated as -T=yaml). "-T=yaml" / "-T=json" pass the
+// requested format; any other value is rejected at flag-parse time.
+type dumpFormat struct {
+	value string
+}
+
+func (d *dumpFormat) String() string { return d.value }
+
+func (d *dumpFormat) Set(v string) error {
+	switch v {
+	case "true", "yaml":
+		d.value = "yaml"
+	case "json":
+		d.value = "json"
+	default:
+		return fmt.Errorf("invalid -T format %q (must be yaml or json)", v)
+	}
+	return nil
+}
+
+// IsBoolFlag makes bare "-T" legal (flag package then calls Set("true")).
+func (d *dumpFormat) IsBoolFlag() bool { return true }
+
+// ANSI SGR sequences used to dim the stderr pre-edit section on a TTY.
+const (
+	ansiDim   = "\x1b[2m"
+	ansiReset = "\x1b[0m"
+)
+
+// shouldColor reports whether ANSI color codes should be emitted to
+// f. It returns false when NO_COLOR is set (per https://no-color.org/)
+// or when f is not a character device (file / pipe / bytes.Buffer),
+// so redirected streams stay free of escape codes.
+func shouldColor(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// testOrDump runs the config pipeline (Load → Edit → Validate →
+// FromTreeMaps) without starting any server, then either reports
+// success (-t) or writes the final config to stdout (-T). When -e
+// was applied, the pre-Edit tree.Map is included in the dump as a
+// second section so users can diff "as written" vs "as served".
+// dimStderr wraps the stderr pre-edit section in ANSI dim codes so a
+// TTY reader's eye naturally falls on the primary (stdout) output.
+func (d *FastHttpd) testOrDump(stdout, stderr io.Writer, dimStderr bool) error {
+	ms, err := d.loadTreeMaps()
+	if err != nil {
+		return err
+	}
+
+	var preEdit []tree.Map
+	if d.dumpFormat.value != "" && len(d.editExprs) > 0 {
+		preEdit = cloneTreeMaps(ms)
+	}
+
+	ms, err = config.Edit(ms, d.editExprs)
+	if err != nil {
+		return err
+	}
+	if err := config.ValidateTreeMaps(ms); err != nil {
+		return err
+	}
+	cfgs, err := config.FromTreeMaps(ms)
+	if err != nil {
+		return err
+	}
+
+	if d.dumpFormat.value == "" {
+		_, err := fmt.Fprintln(stderr, "configuration test is successful")
+		return err
+	}
+	return writeDump(stdout, stderr, preEdit, cfgs, d.dumpFormat.value, dimStderr)
+}
+
+// cloneTreeMaps deep-copies ms so a subsequent in-place Edit leaves
+// the snapshot untouched.
+func cloneTreeMaps(ms []tree.Map) []tree.Map {
+	out := make([]tree.Map, len(ms))
+	for i, m := range ms {
+		if c, ok := tree.CloneDeep(m).(tree.Map); ok {
+			out[i] = c
+		}
+	}
+	return out
+}
+
+// writeDump emits the normalized []Config to stdout and (when -e was
+// applied) the pre-Edit tree.Map to stderr, so stdout stays a single
+// parseable document in the requested format. A trailing blank line
+// is appended to the stderr block in both formats so subsequent
+// terminal output (next prompt or interleaved stdout tail) stays
+// visually separated. If dimStderr is set, the whole stderr block
+// (content + trailing newline) is wrapped in ANSI dim codes.
+func writeDump(stdout, stderr io.Writer, preEdit []tree.Map, cfgs []config.Config, format string, dimStderr bool) error {
+	if len(preEdit) > 0 {
+		if dimStderr {
+			if _, err := fmt.Fprint(stderr, ansiDim); err != nil {
+				return err
+			}
+		}
+		if err := writeTreeMaps(stderr, preEdit, format); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(stderr); err != nil {
+			return err
+		}
+		if dimStderr {
+			if _, err := fmt.Fprint(stderr, ansiReset); err != nil {
+				return err
+			}
+		}
+	}
+	return writeConfigs(stdout, cfgs, format)
+}
+
+// writeTreeMaps serializes ms in the requested format. YAML uses
+// multi-document streams with `---` separators; JSON emits a single
+// array.
+func writeTreeMaps(w io.Writer, ms []tree.Map, format string) error {
+	switch format {
+	case "yaml":
+		for i, m := range ms {
+			if i > 0 {
+				if _, err := fmt.Fprintln(w, "---"); err != nil {
+					return err
+				}
+			}
+			b, err := tree.MarshalYAML(m)
+			if err != nil {
+				return err
+			}
+			if _, err := w.Write(b); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "json":
+		arr := make(tree.Array, len(ms))
+		for i, m := range ms {
+			arr[i] = m
+		}
+		b, err := tree.MarshalJSON(arr)
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(w)
+		return err
+	default:
+		return fmt.Errorf("unknown dump format %q", format)
+	}
+}
+
+// writeConfigs serializes cfgs in the requested format. YAML emits
+// each config as its own `---`-separated document; JSON emits a
+// single array.
+func writeConfigs(w io.Writer, cfgs []config.Config, format string) error {
+	switch format {
+	case "yaml":
+		b, err := yaml.Marshal(cfgs)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		return err
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(cfgs)
+	default:
+		return fmt.Errorf("unknown dump format %q", format)
+	}
+}

--- a/pkg/cmd/dump_test.go
+++ b/pkg/cmd/dump_test.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestShouldColor(t *testing.T) {
+	t.Run("nil file returns false", func(t *testing.T) {
+		if shouldColor(nil) {
+			t.Error("shouldColor(nil) = true, want false")
+		}
+	})
+	t.Run("regular file returns false", func(t *testing.T) {
+		tmp, err := os.CreateTemp(t.TempDir(), "color-*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tmp.Close()
+		if shouldColor(tmp) {
+			t.Error("shouldColor(regular file) = true, want false")
+		}
+	})
+	t.Run("NO_COLOR forces false", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+		// os.Stdout may or may not be a TTY under `go test`, but
+		// NO_COLOR must short-circuit regardless.
+		if shouldColor(os.Stdout) {
+			t.Error("shouldColor with NO_COLOR=1 returned true")
+		}
+	})
+}
+
+func TestDumpFormatSet(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		input    string
+		want     string
+		wantErr  string
+	}{
+		{caseName: "bare -T (IsBoolFlag path)", input: "true", want: "yaml"},
+		{caseName: "explicit yaml", input: "yaml", want: "yaml"},
+		{caseName: "explicit json", input: "json", want: "json"},
+		{caseName: "rejects junk", input: "xml", wantErr: "invalid -T format"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			var d dumpFormat
+			err := d.Set(tc.input)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if d.value != tc.want {
+				t.Errorf("value = %q, want %q", d.value, tc.want)
+			}
+		})
+	}
+}
+
+func TestFastHttpd_TestOrDump(t *testing.T) {
+	// loadTreeMaps() os.Chdir's into the configFile's directory, so
+	// save and restore cwd to keep subtests isolated.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	testCases := []struct {
+		caseName   string
+		configFile string
+		editExprs  []string
+		dumpFormat string
+		isTest     bool
+		dimStderr  bool
+		wantStdout []string
+		missStdout []string
+		wantStderr []string
+		missStderr []string
+		wantErr    string
+	}{
+		{
+			caseName:   "-t on minimal fallback succeeds",
+			isTest:     true,
+			wantStderr: []string{"configuration test is successful"},
+			missStdout: []string{"host"},
+		},
+		{
+			caseName:   "-t reports load error",
+			isTest:     true,
+			configFile: "/nonexistent-dir-for-fasthttpd-test/no.yaml",
+			wantErr:    "no such file",
+		},
+		{
+			caseName:   "-T=yaml without -e dumps only normalized to stdout",
+			dumpFormat: "yaml",
+			wantStdout: []string{"- host: localhost", "listen: :8080"},
+			missStderr: []string{"host: localhost"},
+		},
+		{
+			caseName:   "-T=yaml with -e sends pre-edit to stderr, normalized to stdout",
+			dumpFormat: "yaml",
+			editExprs:  []string{"listen=:9000"},
+			// stdout = normalized []Config (array form with leading
+			// "- ", Config.SetDefaults-supplied fields like
+			// shutdownTimeout, and the -e override).
+			// stderr = pre-edit tree.Map (bare top-level keys, no
+			// array wrap, no Config defaults, no header line).
+			wantStdout: []string{"- host: localhost", "listen: :9000", "shutdownTimeout:"},
+			wantStderr: []string{"host: localhost"},
+			missStderr: []string{"- host:", "listen: :9000", "shutdownTimeout:", "# pre-edit"},
+		},
+		{
+			caseName:   "-T=json without -e dumps bare array",
+			dumpFormat: "json",
+			wantStdout: []string{`[`, `"Host": "localhost"`},
+			missStdout: []string{`"preEdit"`, `"normalized"`},
+		},
+		{
+			caseName:   "-T=json with -e splits streams",
+			dumpFormat: "json",
+			editExprs:  []string{"listen=:9000"},
+			wantStdout: []string{`"Listen": ":9000"`},
+			missStdout: []string{`"preEdit"`, `"normalized"`},
+			wantStderr: []string{`"host"`, `"localhost"`},
+			missStderr: []string{`":9000"`},
+		},
+		{
+			caseName:   "dimStderr wraps pre-edit section in ANSI dim codes",
+			dumpFormat: "yaml",
+			editExprs:  []string{"listen=:9000"},
+			dimStderr:  true,
+			wantStdout: []string{"listen: :9000"},
+			// dim codes must only touch stderr (stdout stays clean
+			// for pipelines).
+			missStdout: []string{"\x1b["},
+			wantStderr: []string{"\x1b[2m", "host: localhost", "\x1b[0m"},
+		},
+		{
+			caseName:   "dimStderr=false leaves stderr escape-free",
+			dumpFormat: "yaml",
+			editExprs:  []string{"listen=:9000"},
+			dimStderr:  false,
+			wantStderr: []string{"host: localhost"},
+			missStderr: []string{"\x1b["},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if err := os.Chdir(cwd); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			d := &FastHttpd{
+				configFile: tc.configFile,
+				editExprs:  tc.editExprs,
+				isTest:     tc.isTest,
+				dumpFormat: dumpFormat{value: tc.dumpFormat},
+			}
+			err := d.testOrDump(&stdout, &stderr, tc.dimStderr)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+			}
+			for _, sub := range tc.wantStdout {
+				if !strings.Contains(stdout.String(), sub) {
+					t.Errorf("stdout missing %q; got:\n%s", sub, stdout.String())
+				}
+			}
+			for _, sub := range tc.missStdout {
+				if strings.Contains(stdout.String(), sub) {
+					t.Errorf("stdout unexpectedly contains %q; got:\n%s", sub, stdout.String())
+				}
+			}
+			for _, sub := range tc.wantStderr {
+				if !strings.Contains(stderr.String(), sub) {
+					t.Errorf("stderr missing %q; got:\n%s", sub, stderr.String())
+				}
+			}
+			for _, sub := range tc.missStderr {
+				if strings.Contains(stderr.String(), sub) {
+					t.Errorf("stderr unexpectedly contains %q; got:\n%s", sub, stderr.String())
+				}
+			}
+		})
+	}
+}

--- a/pkg/cmd/fasthttpd.go
+++ b/pkg/cmd/fasthttpd.go
@@ -39,6 +39,9 @@ const (
 	examplesText = `Examples:
   % fasthttpd -f ./examples/config.minimal.yaml
   % fasthttpd -e root=./examples/public -e listen=:8080
+  % fasthttpd -t -f ./examples/config.minimal.yaml
+  % fasthttpd -T -f ./examples/config.minimal.yaml -e listen=:9000
+  % fasthttpd -T=json -f ./examples/config.minimal.yaml
 `
 )
 
@@ -63,6 +66,8 @@ type FastHttpd struct {
 	flagSet          *flag.FlagSet
 	isVersion        bool
 	isHelp           bool
+	isTest           bool
+	dumpFormat       dumpFormat
 	configFile       string
 	editExprs        util.StringList
 	servers          []*fasthttp.Server
@@ -85,6 +90,8 @@ func (d *FastHttpd) initFlagSet(args []string) error {
 	s.BoolVar(&d.isHelp, "h", false, "help for "+cmd)
 	s.StringVar(&d.configFile, "f", os.Getenv(EnvFasthttpdConfig), "configuration file")
 	s.Var(&d.editExprs, "e", "edit expression (eg. -e KEY=VALUE)")
+	s.BoolVar(&d.isTest, "t", false, "test configuration and exit")
+	s.Var(&d.dumpFormat, "T", "test configuration and dump it (yaml|json; default yaml)")
 	s.Usage = func() {
 		fmt.Fprintf(os.Stderr, "%s\n\nUsage:\n  %s\n\n", desc, usage)
 		fmt.Fprintln(os.Stderr, "Flags:")
@@ -278,7 +285,14 @@ func (d *FastHttpd) Main(args []string) error {
 		fmt.Println(version)
 		return nil
 	}
-	if d.isHelp || (d.configFile == "" && len(d.editExprs) == 0) {
+	if d.isHelp {
+		d.flagSet.Usage()
+		return nil
+	}
+	if d.isTest || d.dumpFormat.value != "" {
+		return d.testOrDump(os.Stdout, os.Stderr, shouldColor(os.Stderr))
+	}
+	if d.configFile == "" && len(d.editExprs) == 0 {
 		d.flagSet.Usage()
 		return nil
 	}


### PR DESCRIPTION
## Summary

Adds nginx-style `-t` / `-T` flags so the config pipeline (Load → Edit → Validate → FromTreeMaps) can be exercised without starting any server.

- `-t`: validate only. Prints `configuration test is successful` on stderr and exits 0, or surfaces the first error and exits non-zero.
- `-T` (alias `-T=yaml`): validate + dump the normalized `[]Config` to stdout as YAML.
- `-T=json`: validate + dump the normalized `[]Config` to stdout as a JSON array (bare, no wrapper object — pipeline-friendly).

## Stream split

When `-e` is also given, the **pre-Edit `[]tree.Map`** is sent to **stderr** in the same format, so users can compare "as written" against "as served" without polluting stdout:

```
% fasthttpd -T -f config.yaml -e listen=:9000          # both streams on TTY
% fasthttpd -T -f config.yaml -e ... 2> pre.yaml       # save pre-edit aside
% fasthttpd -T=json -f config.yaml -e ... 2>/dev/null | jq .   # clean pipeline
```

Stdout is always a single parseable document regardless of `-e`, so downstream `jq` / `yq` consumers never see a wrapper object.

## Readability

When stderr is a TTY, the pre-Edit block is wrapped in ANSI dim codes so the reader's eye falls on the primary (stdout) output. Respects [`NO_COLOR`](https://no-color.org/); escape codes are suppressed whenever stderr is piped or redirected to a file.

A trailing blank line follows the pre-Edit block so subsequent terminal output (next prompt or interleaved stdout tail) stays visually separated.

## File layout

All dump/test-specific code — `dumpFormat`, `shouldColor`, `testOrDump`, `writeDump`, `writeTreeMaps`, `writeConfigs`, `cloneTreeMaps` — lives in a new [pkg/cmd/dump.go](pkg/cmd/dump.go) with matching [pkg/cmd/dump_test.go](pkg/cmd/dump_test.go). `fasthttpd.go` continues to hold server startup, signal handling, and flag wiring.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `-t` smoke: success on minimal fallback, error propagation on missing file
- [x] `-T` / `-T=yaml` / `-T=json` smoke, with and without `-e`
- [x] Captured stderr parses as YAML/JSON (`2> pre.json | jq .`)
- [x] `NO_COLOR=1` and captured streams emit no escape codes
- [x] `go run ./cmd/fasthttpd -f ./examples/config.minimal.yaml` smoke test — confirm the normal server flow still starts cleanly before merge
