### PR TITLE
fix(config): Let -e pass YAML flow array / map literals

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -97,7 +97,14 @@ func Edit(ms []tree.Map, exprs []string) ([]tree.Map, error) {
 			if !strings.HasPrefix(lr[0], ".") {
 				lr[0] = ".[]." + lr[0]
 			}
+			// Auto-quote bare strings so shell-friendly forms like
+			// "root=./public" still parse. Values that already look
+			// like a YAML/JSON literal — quoted strings, bools, null,
+			// integers, or flow array/map ("[...]", "{...}") — are
+			// left untouched and handed straight to tree.Edit.
 			if !strings.HasPrefix(lr[1], `"`) &&
+				!strings.HasPrefix(lr[1], "[") &&
+				!strings.HasPrefix(lr[1], "{") &&
 				lr[1] != "true" && lr[1] != "false" && lr[1] != "null" {
 				if _, err := strconv.Atoi(lr[1]); err != nil {
 					lr[1] = strconv.Quote(lr[1])

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -184,6 +184,32 @@ func TestEdit(t *testing.T) {
 			},
 		},
 		{
+			caseName: "array literal is handed through as YAML flow",
+			exprs:    []string{"indexNames=[index.php, fallback.html]"},
+			check: func(t *testing.T, ms []tree.Map) {
+				arr := ms[0].Get("indexNames").Array()
+				if len(arr) != 2 {
+					t.Fatalf("indexNames length = %d, want 2", len(arr))
+				}
+				if got := arr[0].Value().String(); got != "index.php" {
+					t.Errorf("indexNames[0] = %q, want %q", got, "index.php")
+				}
+				if got := arr[1].Value().String(); got != "fallback.html" {
+					t.Errorf("indexNames[1] = %q, want %q", got, "fallback.html")
+				}
+			},
+		},
+		{
+			caseName: "map literal is handed through as YAML flow",
+			exprs:    []string{"headers={Content-Type: text/plain}"},
+			check: func(t *testing.T, ms []tree.Map) {
+				got := ms[0].Get("headers").Get("Content-Type").Value().String()
+				if got != "text/plain" {
+					t.Errorf("headers.Content-Type = %q, want %q", got, "text/plain")
+				}
+			},
+		},
+		{
 			caseName: "invalid expression returns error",
 			exprs:    []string{"not a valid expr"},
 			wantErr:  "syntax error",


### PR DESCRIPTION
## Summary

Lets `-e` accept YAML flow array / map literals on the command line.

Before this change, `config.Edit` auto-quoted any RHS that did not start with `"`, was not `true` / `false` / `null`, and did not parse as an integer. That meant `-e handlers.static.indexNames=[index.php, fallback.html]` ended up as the string `"[index.php, fallback.html]"` instead of an array.

After this change, the auto-quote is skipped when the RHS starts with `[` or `{`, so the value is handed straight to `tree.Edit` which parses it as YAML (arrays, maps, etc.). All existing bare-string / integer / bool / null / already-quoted behavior is preserved.

## Scope

`config.Edit` only. `tree.Edit`'s YAML semantics are unchanged — the auto-quoting is a CLI-wrapper concern and belongs in this layer.

## Example

```sh
# Before: indexNames becomes the string "[index.php, fallback.html]"
# After:  indexNames becomes ["index.php", "fallback.html"]
fasthttpd -T -f config.yaml \
  -e 'handlers.static.indexNames=[index.php, fallback.html]'
```

Works with `-T` (added in #65) so users can see the flow array actually landing in the normalized `[]Config` dump on stdout.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `TestEdit` covers new rows for array and map literals, existing rows for bare string / integer / bool / explicit prefix still pass
- [x] End-to-end smoke: `-T -e 'handlers.static.indexNames=[index.php, fallback.html]'` shows the array in the final Config dump
- [x] `golangci-lint run ./...` — clean
