### PR TITLE
docs(readme): Highlight schema validation and -t / -T in Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ FastHttpd is a lightweight http server using [valyala/fasthttp](https://github.c
 - Support TLS (HTTPS/SSL)
 - Automatic TLS certificates via Let's Encrypt (autocert / ACME)
 - Virtual hosts
-- YAML configuration
+- YAML configuration with schema-based validation
+- Test and dump the final configuration (`-t` / `-T`, nginx-style)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Surfaces two v0.11-era capabilities in the top-level Features list so the README reflects what fasthttpd actually ships today:

- Schema-based config validation (#63) — typos in the config now fail fast at startup with a friendly path/reason, instead of silently being ignored.
- `-t` / `-T` flags (#65) — validate and/or dump the final normalized configuration without starting the server, nginx-style.

## Diff

```diff
- YAML configuration
+ YAML configuration with schema-based validation
+ Test and dump the final configuration (`-t` / `-T`, nginx-style)
```

The existing Quick start / "Test and dump the final configuration" sections already cover these in depth; this PR just makes them discoverable from the Features list.

## Test plan

- [x] `go test ./...` — no code changes; existing tests unaffected
- [x] README renders correctly on GitHub (bulletted list, no stray markdown)
