### PR TITLE
feat(config): Validate typed Config via tree/schema

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -94,8 +94,17 @@ func Edit(ms []tree.Map, exprs []string) ([]tree.Map, error) {
 	for _, expr := range exprs {
 		lr := strings.SplitN(expr, "=", 2)
 		if len(lr) == 2 {
-			if !strings.HasPrefix(lr[0], ".") {
-				lr[0] = ".[]." + lr[0]
+			// Auto-prefix .[] so the expression applies to every
+			// document in the wrapped array. An LHS already starting
+			// with .[ (e.g. .[].foo or .[0].foo) is taken as
+			// explicit doc targeting and left alone.
+			switch {
+			case strings.HasPrefix(lr[0], ".["):
+				// already explicit
+			case strings.HasPrefix(lr[0], "."):
+				lr[0] = ".[]" + lr[0] // .foo → .[].foo
+			default:
+				lr[0] = ".[]." + lr[0] // foo → .[].foo
 			}
 			// Auto-quote bare strings so shell-friendly forms like
 			// "root=./public" still parse. Values that already look

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -131,21 +131,20 @@ func Edit(ms []tree.Map, exprs []string) ([]tree.Map, error) {
 	return out, nil
 }
 
-// FromTreeMap converts a tree.Map document into a Config. The map is
-// routed through a YAML decoder with KnownFields(true) so typos in
-// typed portions of Config (Host / Listen / SSL / Log / AccessLog /
-// Routes / RoutesCache / Server) fail loudly rather than being
-// silently dropped. After decode, SetDefaults fills unset fields and
-// Normalize applies the remaining fixups.
+// FromTreeMap converts a tree.Map document into a Config. Schema
+// validation (via [ValidateTreeMaps]) is expected to run upstream;
+// once it succeeds, every key in m is known and every leaf has a
+// type compatible with the corresponding Config field, so the YAML
+// decoder here does not need KnownFields(true). After decode,
+// SetDefaults fills unset fields and Normalize applies the remaining
+// fixups.
 func FromTreeMap(m tree.Map) (Config, error) {
 	cfg := Config{}.SetDefaults()
 	data, err := tree.MarshalYAML(m)
 	if err != nil {
 		return cfg, err
 	}
-	dec := yaml.NewDecoder(bytes.NewReader(data))
-	dec.KnownFields(true)
-	if err := dec.Decode(&cfg); err != nil {
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return cfg, err
 	}
 	return cfg.Normalize()

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -184,6 +184,24 @@ func TestEdit(t *testing.T) {
 			},
 		},
 		{
+			caseName: "leading-dot path applies to each document",
+			exprs:    []string{".host=\"sub.example\""},
+			check: func(t *testing.T, ms []tree.Map) {
+				if got := ms[0].Get("host").Value().String(); got != "sub.example" {
+					t.Errorf("host = %q, want %q", got, "sub.example")
+				}
+			},
+		},
+		{
+			caseName: "nested leading-dot path reaches sub-fields",
+			exprs:    []string{".routesCache.expire=60"},
+			check: func(t *testing.T, ms []tree.Map) {
+				if got := ms[0].Get("routesCache").Get("expire").Value().Int(); got != 60 {
+					t.Errorf("routesCache.expire = %d, want 60", got)
+				}
+			},
+		},
+		{
 			caseName: "array literal is handed through as YAML flow",
 			exprs:    []string{"indexNames=[index.php, fallback.html]"},
 			check: func(t *testing.T, ms []tree.Map) {

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -40,6 +42,105 @@ func RegisterFilterSchema(typeName string, rules schema.QueryRules) {
 	filterSchemas[typeName] = rules
 }
 
+// SchemaRuler is implemented by types whose schema rule cannot be
+// derived from their Go type alone — typically types with a custom
+// YAML unmarshaler that accepts multiple input shapes (e.g. [Duration]
+// accepts both "60s" and an integer nanoseconds value).
+//
+// [SchemaFromStruct] honors this method when building the schema for
+// a struct field of type T (or *T) where T implements SchemaRuler.
+type SchemaRuler interface {
+	SchemaRule() schema.Rule
+}
+
+// SchemaFromStruct walks v's type via reflect and returns a
+// [schema.Map] whose KeyedRules mirror the struct's yaml-tagged
+// fields. Nested structs recurse; types implementing [SchemaRuler]
+// override the default kind-based mapping.
+//
+// The key for each field follows the yaml/v3 decoder convention:
+// the `yaml:"..."` tag's name, or — when the tag is absent — the
+// lowercased Go field name. Fields tagged `yaml:"-"` and unexported
+// fields are skipped.
+//
+// Intended for the typed [Config] struct so that schema-driven
+// validation can report unknown keys and type mismatches in the same
+// jq-path format used for handlers / filters.
+func SchemaFromStruct(v any) schema.Map {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return schemaMapFromType(t)
+}
+
+var (
+	schemaRulerIface = reflect.TypeFor[SchemaRuler]()
+	treeMapType      = reflect.TypeFor[tree.Map]()
+)
+
+// ruleForType maps a Go type to the [schema.Rule] that validates a
+// node of that type. Custom types implementing [SchemaRuler] short-
+// circuit the kind-based default. [tree.Map] is special-cased as an
+// "open" map (no allow-list) because handler / filter contents are
+// validated by their own registered schemas.
+func ruleForType(t reflect.Type) schema.Rule {
+	if t.Implements(schemaRulerIface) {
+		return reflect.Zero(t).Interface().(SchemaRuler).SchemaRule()
+	}
+	if reflect.PointerTo(t).Implements(schemaRulerIface) {
+		return reflect.New(t).Interface().(SchemaRuler).SchemaRule()
+	}
+	if t == treeMapType {
+		return schema.Map{}
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return schema.String{}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return schema.Int{}
+	case reflect.Float32, reflect.Float64:
+		return schema.Float{}
+	case reflect.Bool:
+		return schema.Bool{}
+	case reflect.Slice, reflect.Array:
+		return schema.Every{Rules: schema.QueryRules{".": ruleForType(t.Elem())}}
+	case reflect.Map:
+		return schema.Every{Rules: schema.QueryRules{".": ruleForType(t.Elem())}}
+	case reflect.Struct:
+		return schemaMapFromType(t)
+	case reflect.Pointer:
+		return ruleForType(t.Elem())
+	default:
+		return schema.Map{}
+	}
+}
+
+// schemaMapFromType builds a [schema.Map] with KeyedRules from a
+// struct type. Each exported field is mapped using the same key the
+// yaml/v3 decoder would use: the `yaml:"..."` tag's name, or — when
+// the tag is absent — the lowercased Go field name.
+func schemaMapFromType(t reflect.Type) schema.Map {
+	rules := map[string]schema.Rule{}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := f.Tag.Get("yaml")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = strings.ToLower(f.Name)
+		}
+		rules[name] = ruleForType(f.Type)
+	}
+	return schema.Map{KeyedRules: rules}
+}
+
 // DurationRule validates a value expressible as time.Duration: either
 // a string parseable by time.ParseDuration ("60s") or an integer
 // (interpreted as nanoseconds, matching Config.Normalize's output).
@@ -73,6 +174,38 @@ func (r DurationRule) Validate(n tree.Node, q string) error {
 	}
 	return nil
 }
+
+// SchemaRule lets [SchemaFromStruct] map a [Duration]-typed field to
+// [DurationRule] instead of the default schema.Int{}.
+func (Duration) SchemaRule() schema.Rule { return DurationRule{} }
+
+// SizeRule validates a value expressible as a [Size]: either a string
+// parseable by parseSize ("4k", "8 KiB") or a plain integer literal
+// (interpreted as a byte count). Mirrors [DurationRule] in shape so
+// schema errors for Size and Duration follow the same template.
+type SizeRule struct{}
+
+// Validate implements schema.Rule.
+func (SizeRule) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	switch {
+	case n.Type().IsStringValue():
+		if _, err := parseSize(n.Value().String()); err != nil {
+			return fmt.Errorf("%s: %w", q, err)
+		}
+	case n.Type().IsNumberValue():
+		// Any integer is a valid byte count.
+	default:
+		return fmt.Errorf("%s: expected size (string or number), got %s", q, n.Type().String())
+	}
+	return nil
+}
+
+// SchemaRule lets [SchemaFromStruct] map a [Size]-typed field to
+// [SizeRule] instead of the default schema.Int{}.
+func (Size) SchemaRule() schema.Rule { return SizeRule{} }
 
 // HandlerDispatch validates a single handler entry: it reads the
 // ".type" field and applies the QueryRules registered under that

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -272,22 +272,27 @@ func lookupFilterRules(t string) (schema.QueryRules, bool) {
 }
 
 // topLevelRules describes the document-root shape for schema-driven
-// validation. Only `handlers` / `filters` are checked here — other
-// top-level fields (host, listen, server, routes, ...) are validated
-// by FromTreeMap via the yaml decoder with KnownFields(true).
-var topLevelRules = schema.QueryRules{
-	".handlers": schema.Every{Rules: schema.QueryRules{
+// validation. The base shape is generated from [Config] via reflect
+// (see [SchemaFromStruct]), then the `handlers` / `filters` entries
+// are overridden so per-type registered rules are dispatched against
+// each entry.
+var topLevelRules = func() schema.QueryRules {
+	root := SchemaFromStruct(Config{})
+	root.KeyedRules["handlers"] = schema.Every{Rules: schema.QueryRules{
 		".": HandlerDispatch{},
-	}},
-	".filters": schema.Every{Rules: schema.QueryRules{
+	}}
+	root.KeyedRules["filters"] = schema.Every{Rules: schema.QueryRules{
 		".": FilterDispatch{},
-	}},
-}
+	}}
+	return schema.QueryRules{".": root}
+}()
 
-// ValidateTreeMaps runs schema-driven validation over each document's
-// free-form handlers / filters subtrees. Typed portions of Config
-// (including the Server struct) are validated by FromTreeMap, so
-// this function intentionally does not re-check them.
+// ValidateTreeMaps runs schema-driven validation over each document.
+// The schema covers the entire typed [Config] shape (generated from
+// the struct via reflect) plus dispatched rules for the free-form
+// handlers / filters subtrees. After ValidateTreeMaps succeeds,
+// FromTreeMap can decode the document into Config without
+// KnownFields-style strict checking.
 //
 // When a registered schema rule itself is malformed (its query string
 // fails to parse via tree.Find), the underlying *schema.ErrQuery is

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -75,7 +75,7 @@ func SchemaFromStruct(v any) schema.Map {
 }
 
 var (
-	schemaRulerIface = reflect.TypeFor[SchemaRuler]()
+	schemaRulerType  = reflect.TypeFor[SchemaRuler]()
 	treeMapType      = reflect.TypeFor[tree.Map]()
 )
 
@@ -85,10 +85,10 @@ var (
 // "open" map (no allow-list) because handler / filter contents are
 // validated by their own registered schemas.
 func ruleForType(t reflect.Type) schema.Rule {
-	if t.Implements(schemaRulerIface) {
+	if t.Implements(schemaRulerType) {
 		return reflect.Zero(t).Interface().(SchemaRuler).SchemaRule()
 	}
-	if reflect.PointerTo(t).Implements(schemaRulerIface) {
+	if reflect.PointerTo(t).Implements(schemaRulerType) {
 		return reflect.New(t).Interface().(SchemaRuler).SchemaRule()
 	}
 	if t == treeMapType {
@@ -271,12 +271,12 @@ func lookupFilterRules(t string) (schema.QueryRules, bool) {
 	return rules, ok
 }
 
-// topLevelRules describes the document-root shape for schema-driven
-// validation. The base shape is generated from [Config] via reflect
-// (see [SchemaFromStruct]), then the `handlers` / `filters` entries
-// are overridden so per-type registered rules are dispatched against
-// each entry.
-var topLevelRules = func() schema.QueryRules {
+// rootRules returns the QueryRules describing the document-root shape
+// for schema-driven validation. The base shape is generated from
+// [Config] via reflect (see [SchemaFromStruct]), then the `handlers`
+// / `filters` entries are overridden so per-type registered rules are
+// dispatched against each entry.
+func rootRules() schema.QueryRules {
 	root := SchemaFromStruct(Config{})
 	root.KeyedRules["handlers"] = schema.Every{Rules: schema.QueryRules{
 		".": HandlerDispatch{},
@@ -285,7 +285,7 @@ var topLevelRules = func() schema.QueryRules {
 		".": FilterDispatch{},
 	}}
 	return schema.QueryRules{".": root}
-}()
+}
 
 // ValidateTreeMaps runs schema-driven validation over each document.
 // The schema covers the entire typed [Config] shape (generated from
@@ -300,13 +300,14 @@ var topLevelRules = func() schema.QueryRules {
 // apart from a config error. The original *schema.ErrQuery remains
 // reachable via errors.As.
 func ValidateTreeMaps(ms []tree.Map) error {
+	rules := rootRules()
 	var errs []error
 	for i, m := range ms {
 		prefix := ""
 		if len(ms) > 1 {
 			prefix = fmt.Sprintf("documents[%d]", i)
 		}
-		if err := schema.ValidateWithPrefix(m, topLevelRules, prefix); err != nil {
+		if err := schema.ValidateWithPrefix(m, rules, prefix); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -47,6 +47,48 @@ func TestValidateTreeMaps(t *testing.T) {
 			}},
 			wantErr: ".handlers: expected array or map",
 		},
+		{
+			caseName: "unknown top-level key",
+			docs: []tree.Map{{
+				"listn": tree.V(":8080"), // typo of "listen"
+			}},
+			wantErr: `.: unknown key "listn"`,
+		},
+		{
+			caseName: "wrong type on top-level field",
+			docs: []tree.Map{{
+				"routes": tree.V("single"), // want array of Route
+			}},
+			wantErr: ".routes: expected array or map",
+		},
+		{
+			caseName: "unknown server field",
+			docs: []tree.Map{{
+				"server": tree.Map{"futureField": tree.V("x")},
+			}},
+			wantErr: `.server: unknown key "futureField"`,
+		},
+		{
+			caseName: "wrong type on server field",
+			docs: []tree.Map{{
+				"server": tree.Map{"concurrency": tree.V("many")},
+			}},
+			wantErr: ".server.concurrency: expected number, got string",
+		},
+		{
+			caseName: "invalid server duration",
+			docs: []tree.Map{{
+				"server": tree.Map{"readTimeout": tree.V("not-a-duration")},
+			}},
+			wantErr: `.server.readTimeout: invalid duration "not-a-duration"`,
+		},
+		{
+			caseName: "invalid server size",
+			docs: []tree.Map{{
+				"server": tree.Map{"readBufferSize": tree.V("not-a-size")},
+			}},
+			wantErr: `.server.readBufferSize: invalid size "not-a-size"`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {
@@ -67,78 +109,21 @@ func TestValidateTreeMaps(t *testing.T) {
 	}
 }
 
-// TestFromTreeMap exercises the typed Config decoding path. Unknown
-// top-level keys fail KnownFields strict decoding; unknown Server
-// fields fail the same way one level deeper; invalid duration values
-// fail Duration.UnmarshalYAML.
+// TestFromTreeMap exercises the typed Config decoding path on a
+// schema-valid input. Error cases (unknown keys, wrong types, invalid
+// durations) are exercised against ValidateTreeMaps in
+// TestValidateTreeMaps — once the schema layer accepts a document,
+// FromTreeMap can decode it without re-checking those constraints.
 func TestFromTreeMap(t *testing.T) {
-	testCases := []struct {
-		caseName string
-		doc      tree.Map
-		wantErr  string // substring; empty means success
-	}{
-		{
-			caseName: "valid server",
-			doc: tree.Map{
-				"server": tree.Map{
-					"name":        tree.V("fasthttpd"),
-					"concurrency": tree.V(100),
-					"readTimeout": tree.V("60s"),
-				},
-			},
-		},
-		{
-			caseName: "unknown top-level key",
-			doc: tree.Map{
-				"listn": tree.V(":8080"), // typo of "listen"
-			},
-			wantErr: "field listn not found",
-		},
-		{
-			caseName: "wrong type on known top-level field",
-			doc: tree.Map{
-				"routes": tree.V("single"), // want array of Route
-			},
-			wantErr: "cannot unmarshal",
-		},
-		{
-			caseName: "unknown server field",
-			doc: tree.Map{
-				"server": tree.Map{"futureField": tree.V("x")},
-			},
-			wantErr: "field futureField not found",
-		},
-		{
-			caseName: "wrong type on known server field",
-			doc: tree.Map{
-				"server": tree.Map{"concurrency": tree.V("many")},
-			},
-			wantErr: "cannot unmarshal !!str `many` into int",
-		},
-		{
-			caseName: "invalid server duration",
-			doc: tree.Map{
-				"server": tree.Map{"readTimeout": tree.V("not-a-duration")},
-			},
-			wantErr: "invalid duration",
+	doc := tree.Map{
+		"server": tree.Map{
+			"name":        tree.V("fasthttpd"),
+			"concurrency": tree.V(100),
+			"readTimeout": tree.V("60s"),
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.caseName, func(t *testing.T) {
-			_, err := FromTreeMap(tc.doc)
-			if tc.wantErr == "" {
-				if err != nil {
-					t.Fatalf("FromTreeMap returned %v, want nil", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("FromTreeMap returned nil, want error containing %q", tc.wantErr)
-			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
-			}
-		})
+	if _, err := FromTreeMap(doc); err != nil {
+		t.Fatalf("FromTreeMap returned %v, want nil", err)
 	}
 }
 

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -165,6 +165,136 @@ func TestDurationRule_Validate(t *testing.T) {
 	}
 }
 
+func TestSizeRule_Validate(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		node     tree.Node
+		wantErr  string
+	}{
+		{caseName: "string ok", node: tree.V("4k")},
+		{caseName: "string with spaces ok", node: tree.V("8 KiB")},
+		{caseName: "number ok", node: tree.V(int64(4096))},
+		{caseName: "nil skipped", node: tree.Nil},
+		{caseName: "invalid string", node: tree.V("not"), wantErr: "invalid size"},
+		{caseName: "bool rejected", node: tree.V(true), wantErr: "expected size"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := SizeRule{}.Validate(tc.node, ".x")
+			checkErr(t, err, tc.wantErr)
+		})
+	}
+}
+
+// customRulerType implements [SchemaRuler] to verify the override
+// path in [ruleForType].
+type customRulerType struct{}
+
+func (customRulerType) SchemaRule() schema.Rule { return schema.Bool{} }
+
+// untaggedFieldStruct verifies the lowercased-field-name fallback for
+// fields without a `yaml:"..."` tag — matching yaml/v3 decoder
+// behavior.
+type untaggedFieldStruct struct {
+	Tagged   string `yaml:"explicit"`
+	Rotation string // no tag → key "rotation"
+	skipMe   string //nolint:unused // verifies unexported fields are ignored
+}
+
+// kitchenSink covers the kinds [SchemaFromStruct] must handle: the
+// SchemaRuler override, primitives, slices, maps of strings, maps of
+// tree.Map (special-cased), nested structs, pointers, and tagged-skip.
+type kitchenSink struct {
+	Custom   customRulerType     `yaml:"custom"`
+	Str      string              `yaml:"str"`
+	Int      int                 `yaml:"int"`
+	Bool     bool                `yaml:"bool"`
+	Float    float64             `yaml:"float"`
+	Slice    []string            `yaml:"slice"`
+	Strs     map[string]string   `yaml:"strs"`
+	RawMap   tree.Map            `yaml:"rawMap"`
+	Maps     map[string]tree.Map `yaml:"maps"`
+	Nested   untaggedFieldStruct `yaml:"nested"`
+	PtrToInt *int                `yaml:"ptrToInt"`
+	Skipped  string              `yaml:"-"`
+	Untagged bool                // key "untagged"
+}
+
+func TestSchemaFromStruct(t *testing.T) {
+	got := SchemaFromStruct(kitchenSink{})
+
+	wantKeys := []string{
+		"custom", "str", "int", "bool", "float",
+		"slice", "strs", "rawMap", "maps",
+		"nested", "ptrToInt", "untagged",
+	}
+	for _, k := range wantKeys {
+		if _, ok := got.KeyedRules[k]; !ok {
+			t.Errorf("KeyedRules missing key %q", k)
+		}
+	}
+	if _, ok := got.KeyedRules["Skipped"]; ok {
+		t.Errorf(`KeyedRules contains "Skipped"; yaml:"-" should be skipped`)
+	}
+	if _, ok := got.KeyedRules["skipMe"]; ok {
+		t.Errorf(`KeyedRules contains "skipMe"; unexported fields should be skipped`)
+	}
+
+	// SchemaRuler override: customRulerType returns schema.Bool{}.
+	if _, ok := got.KeyedRules["custom"].(schema.Bool); !ok {
+		t.Errorf("custom rule = %T; want schema.Bool", got.KeyedRules["custom"])
+	}
+	// Primitives.
+	if _, ok := got.KeyedRules["str"].(schema.String); !ok {
+		t.Errorf("str rule = %T; want schema.String", got.KeyedRules["str"])
+	}
+	if _, ok := got.KeyedRules["int"].(schema.Int); !ok {
+		t.Errorf("int rule = %T; want schema.Int", got.KeyedRules["int"])
+	}
+	if _, ok := got.KeyedRules["bool"].(schema.Bool); !ok {
+		t.Errorf("bool rule = %T; want schema.Bool", got.KeyedRules["bool"])
+	}
+	if _, ok := got.KeyedRules["float"].(schema.Float); !ok {
+		t.Errorf("float rule = %T; want schema.Float", got.KeyedRules["float"])
+	}
+	// tree.Map → schema.Map{} (no KeyedRules — accept any shape).
+	rawMap, ok := got.KeyedRules["rawMap"].(schema.Map)
+	if !ok {
+		t.Errorf("rawMap rule = %T; want schema.Map", got.KeyedRules["rawMap"])
+	} else if len(rawMap.KeyedRules) != 0 {
+		t.Errorf("rawMap rule has KeyedRules; tree.Map should be open")
+	}
+	// Nested struct → schema.Map with KeyedRules.
+	nested, ok := got.KeyedRules["nested"].(schema.Map)
+	if !ok {
+		t.Errorf("nested rule = %T; want schema.Map", got.KeyedRules["nested"])
+	} else {
+		if _, ok := nested.KeyedRules["explicit"]; !ok {
+			t.Errorf(`nested missing "explicit" key (from yaml:"explicit")`)
+		}
+		if _, ok := nested.KeyedRules["rotation"]; !ok {
+			t.Errorf(`nested missing "rotation" key (lowercased Rotation)`)
+		}
+	}
+}
+
+// TestSchemaFromStruct_AppliedToConfig is a smoke test that the
+// generator succeeds on the real Config struct and produces a schema
+// that accepts every key the Config struct actually defines.
+func TestSchemaFromStruct_AppliedToConfig(t *testing.T) {
+	root := SchemaFromStruct(Config{})
+	for _, k := range []string{
+		"host", "listen", "ssl", "root", "server",
+		"log", "accessLog", "errorPages",
+		"filters", "handlers", "routes", "routesCache",
+		"shutdownTimeout",
+	} {
+		if _, ok := root.KeyedRules[k]; !ok {
+			t.Errorf("Config schema missing top-level key %q", k)
+		}
+	}
+}
+
 func TestRegisterHandlerSchema_Dispatch(t *testing.T) {
 	RegisterHandlerSchema("test-fs-handler", schema.QueryRules{
 		".": schema.Map{KeyedRules: map[string]schema.Rule{


### PR DESCRIPTION
## Summary

Routes typed `Config` validation through `tree/schema` (built on top of #71), so all config errors share a uniform tq-style path format.

- New `SchemaFromStruct(v any)` reflects over a struct's yaml tags to build a `schema.Map` mirroring its layout. `topLevelRules` is now generated from `SchemaFromStruct(Config{})` (with `handlers` / `filters` overridden to the dispatch rules from #71), replacing the previous `yaml.Decoder.KnownFields(true)` typo-detection path.
- `SizeRule` joins `DurationRule`; `Duration` / `Size` wrapper types implement a new `SchemaRuler` interface so `SchemaFromStruct` honors their custom `UnmarshalYAML` semantics (string-or-int).
- `-e` LHS auto-prefixing extended: `.foo` / `.foo.bar` now apply to each document (auto-prefix to `.[].foo`); previously they targeted the wrapped Array root and silently no-op'd.

## User-visible change

`-e .routesCache.expire=x -T=json` previously surfaced a yaml-style decode error; it now emits the schema's tq-path message:

```
.routesCache.expire: expected number, got string
```

`fasthttpd -t` / `-T` against typed-Config typos now behave consistently with handlers / filters — same tq-path format that #71 introduced.

## Stacked on #71

Base of this PR is `feature/tree-schema-migration` (the head of #71). Once #71 merges, this PR will retarget to `main` automatically. They ship together as v0.12.0.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go run ./cmd/fasthttpd -e .routesCache.expire=x -T=json -f examples/config.minimal.yaml` emits `.routesCache.expire: expected number, got string`