### PR TITLE
chore: Bump version to 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 FastHttpd is a lightweight http server using [valyala/fasthttp](https://github.com/valyala/fasthttp).
 
-> FastHttpd and fasthttp are versioned independently. FastHttpd **v0.11.0** is built against fasthttp **v1.70.0**.
+> FastHttpd and fasthttp are versioned independently. FastHttpd **v0.12.0** is built against fasthttp **v1.71.0**.
 
 ## Features
 
@@ -33,7 +33,7 @@ go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
 Download binary from [release](https://github.com/fasthttpd/fasthttpd/releases).
 
 ```sh
-VERSION=0.11.0 GOOS=linux GOARCH=amd64; \
+VERSION=0.12.0 GOOS=linux GOARCH=amd64; \
   curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
   tar xz fasthttpd && \
   sudo mv fasthttpd /usr/sbin
@@ -54,7 +54,7 @@ brew install fasthttpd
 Download deb or rpm from [release](https://github.com/fasthttpd/fasthttpd/releases), and then execute `apt install` or `yum install`. 
 
 ```sh
-VERSION=0.11.0 ARCH=amd64; \
+VERSION=0.12.0 ARCH=amd64; \
   curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
 sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
 Download a binary from the [releases page](https://github.com/fasthttpd/fasthttpd/releases).
 
 ```sh
-VERSION=0.11.0 GOOS=linux GOARCH=amd64; \
+VERSION=0.12.0 GOOS=linux GOARCH=amd64; \
   curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
   tar xz fasthttpd && \
   sudo mv fasthttpd /usr/sbin
@@ -32,7 +32,7 @@ brew install fasthttpd
 Download a `.deb` or `.rpm` package from the [releases page](https://github.com/fasthttpd/fasthttpd/releases), then run `apt install` or `yum install`.
 
 ```sh
-VERSION=0.11.0 ARCH=amd64; \
+VERSION=0.12.0 ARCH=amd64; \
   curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
 sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
 ```


### PR DESCRIPTION
Bump version references for the 0.12.0 release.

Main changes landing in 0.12.0:
- Lowercase keys in `-T=json` output so the key casing matches YAML/CLI usage (#69)
- Handler / filter validation moved to `tree/schema` (KeyedRules + Or), shrinking the schema layer by ~411 LOC (#71)
- Typed `Config` validation also routed through `tree/schema`, so `-e .routesCache.expire=x -T=json` and similar produce schema-style errors (e.g. `.routesCache.expire: expected number, got string`) instead of yaml-decode errors (#72)
- `github.com/valyala/fasthttp` bumped from v1.70.0 to v1.71.0, picking up CRLF-injection sanitization across header / redirect / cookie setters and stricter Transfer-Encoding / chunk-extension parsing (#73)