### PR TITLE
chore: Bump version to 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 FastHttpd is a lightweight http server using [valyala/fasthttp](https://github.com/valyala/fasthttp).
 
-> FastHttpd and fasthttp are versioned independently. FastHttpd **v0.12.0** is built against fasthttp **v1.71.0**.
+> FastHttpd and fasthttp are versioned independently. FastHttpd **v0.12.1** is built against fasthttp **v1.71.0**.
 
 ## Features
 
@@ -33,7 +33,7 @@ go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
 Download binary from [release](https://github.com/fasthttpd/fasthttpd/releases).
 
 ```sh
-VERSION=0.12.0 GOOS=linux GOARCH=amd64; \
+VERSION=0.12.1 GOOS=linux GOARCH=amd64; \
   curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
   tar xz fasthttpd && \
   sudo mv fasthttpd /usr/sbin
@@ -54,7 +54,7 @@ brew install fasthttpd
 Download deb or rpm from [release](https://github.com/fasthttpd/fasthttpd/releases), and then execute `apt install` or `yum install`. 
 
 ```sh
-VERSION=0.12.0 ARCH=amd64; \
+VERSION=0.12.1 ARCH=amd64; \
   curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
 sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ go install github.com/fasthttpd/fasthttpd/cmd/fasthttpd@latest
 Download a binary from the [releases page](https://github.com/fasthttpd/fasthttpd/releases).
 
 ```sh
-VERSION=0.12.0 GOOS=linux GOARCH=amd64; \
+VERSION=0.12.1 GOOS=linux GOARCH=amd64; \
   curl -fsSL "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${GOOS}_${GOARCH}.tar.gz" | \
   tar xz fasthttpd && \
   sudo mv fasthttpd /usr/sbin
@@ -32,7 +32,7 @@ brew install fasthttpd
 Download a `.deb` or `.rpm` package from the [releases page](https://github.com/fasthttpd/fasthttpd/releases), then run `apt install` or `yum install`.
 
 ```sh
-VERSION=0.12.0 ARCH=amd64; \
+VERSION=0.12.1 ARCH=amd64; \
   curl -fsSL -O "https://github.com/fasthttpd/fasthttpd/releases/download/v${VERSION}/fasthttpd_${VERSION}_${ARCH}.deb"
 sudo apt install "./fasthttpd_${VERSION}_${ARCH}.deb"
 ```


### PR DESCRIPTION
Bumps the version strings in `README.md` and `docs/installation.md` from 0.12.0 to 0.12.1 ahead of the v0.12.1 patch release.

v0.12.1 contains dependency-only changes: `golang.org/x/net` v0.55.0 (fixes GO-2026-5026 / CVE-2026-39821) and `golang.org/x/crypto` v0.52.0. fasthttp stays at v1.71.0, so the "built against" line is unchanged.
