### PR TITLE
build: Pin Go toolchain to go1.25.11 for stdlib security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine
+FROM golang:1.25.11-alpine
 
 ENV GO111MODULE=on
 ENV GOPATH=""

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/fasthttpd/fasthttpd
 
 go 1.25.0
 
+toolchain go1.25.11
+
 require (
 	github.com/mojatter/io2 v0.9.0
 	github.com/mojatter/tree v0.12.3


### PR DESCRIPTION
## Summary

Builds release binaries and the Docker image with **go1.25.11**, which carries the Go 1.25 line's standard-library security backports.

`govulncheck ./...` flagged 9 standard-library vulnerabilities reachable from fasthttpd's own code paths (TLS handshake, HTTP/2, reverse proxy, x509, access logging). All are fixed at go1.25.11 — the most recent required being GO-2026-5039 / GO-2026-5037. Notable DoS-class issues for a public HTTP server:

- **GO-2026-4870** — unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection retention and DoS (`crypto/tls`)
- **GO-2026-4918** — infinite loop in the HTTP/2 transport on a bad `SETTINGS_MAX_FRAME_SIZE`
- **GO-2026-4976** — `ReverseProxy` forwards queries beyond the parameter limit (`net/http/httputil`)

The golang.org/x/crypto bump (#79) is unrelated — its fixes live in the `ssh` / `pkcs12` packages, which fasthttpd does not import.

## Changes

- `go.mod`: add `toolchain go1.25.11` (language version stays at 1.25.0)
- `Dockerfile`: pin base image to `golang:1.25.11-alpine`

No source or behavior changes. CI (`go-version-file: go.mod`) picks up the toolchain directive automatically.