### PR TITLE
build: Strip Docker binary with -ldflags="-s -w" -trimpath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV GO111MODULE=on
 ENV GOPATH=""
 
 RUN --mount=target=. GOOS=linux CGO_ENABLED=0 \
-    go build -o /fasthttpd ./cmd/fasthttpd/main.go
+    go build -ldflags="-s -w" -trimpath -o /fasthttpd ./cmd/fasthttpd/main.go
 
 FROM scratch
 


### PR DESCRIPTION
The release binaries built by GoReleaser are already stripped (`.goreleaser.yaml` uses `-s -w`), but the Docker image build used a plain `go build`, leaving the symbol table and DWARF debug info in the binary.

Adding `-ldflags="-s -w" -trimpath` brings the Docker image binary in line with the released binaries.

Measured locally (linux/arm64, single-arch build):

| | before | after | delta |
|---|---|---|---|
| in-image binary | 13.50 MB | 9.50 MB | -30% |
| image CONTENT SIZE | 7.64 MB | 4.13 MB | -46% |
| image DISK USAGE | 21.9 MB | 14.1 MB | -36% |

Since the published image is multi-arch (amd64 + arm64), the saving applies to both architectures.